### PR TITLE
docs(neardata): reconcile vendored REST schemas with builder-docs baseline

### DIFF
--- a/apis/neardata/openapi.yaml
+++ b/apis/neardata/openapi.yaml
@@ -1,5 +1,80 @@
 components:
   schemas:
+    ActionDocument:
+      additionalProperties: true
+      type: object
+    ActionReceiptBody:
+      additionalProperties: false
+      properties:
+        Action:
+          $ref: "#/components/schemas/ActionReceiptDocument"
+      required:
+        - Action
+      type: object
+    ActionReceiptDocument:
+      additionalProperties: false
+      properties:
+        actions:
+          items:
+            $ref: "#/components/schemas/ActionDocument"
+          type: array
+        gas_price:
+          type: string
+        input_data_ids:
+          items:
+            type: string
+          type: array
+        is_promise_yield:
+          type: boolean
+        output_data_receivers:
+          items:
+            $ref: "#/components/schemas/OutputDataReceiverDocument"
+          type: array
+        signer_id:
+          type: string
+        signer_public_key:
+          type: string
+      required:
+        - actions
+        - gas_price
+        - input_data_ids
+        - is_promise_yield
+        - output_data_receivers
+        - signer_id
+        - signer_public_key
+      type: object
+    BlockDocument:
+      additionalProperties: false
+      description: Full block document as served by neardata, including the block envelope and per-shard payloads.
+      properties:
+        block:
+          $ref: "#/components/schemas/BlockEnvelope"
+        shards:
+          items:
+            $ref: "#/components/schemas/ShardDocument"
+          type: array
+      required:
+        - block
+        - shards
+      type: object
+    BlockEnvelope:
+      additionalProperties: false
+      description: Block-level payload returned by neardata.
+      properties:
+        author:
+          description: Block producer account ID.
+          type: string
+        chunks:
+          items:
+            $ref: "#/components/schemas/ChunkHeader"
+          type: array
+        header:
+          $ref: "#/components/schemas/BlockHeader"
+      required:
+        - author
+        - chunks
+        - header
+      type: object
     BlockErrorResponse:
       additionalProperties: false
       properties:
@@ -17,6 +92,224 @@ components:
         - BLOCK_HEIGHT_TOO_LOW
         - BLOCK_DOES_NOT_EXIST
       type: string
+    BlockHeader:
+      additionalProperties: true
+      description: Block header object as served by neardata.
+      properties:
+        chunks_included:
+          format: uint64
+          type: integer
+        epoch_id:
+          type: string
+        gas_price:
+          type: string
+        hash:
+          type: string
+        height:
+          format: uint64
+          type: integer
+        next_epoch_id:
+          type: string
+        prev_hash:
+          type: string
+        prev_height:
+          format: uint64
+          type: integer
+        timestamp:
+          type: integer
+        timestamp_nanosec:
+          type: string
+        total_supply:
+          type: string
+      type: object
+    ChunkDocument:
+      additionalProperties: false
+      description: Chunk payload returned by neardata for a single shard in a selected block.
+      properties:
+        author:
+          description: Chunk producer account ID.
+          type: string
+        header:
+          $ref: "#/components/schemas/ChunkHeader"
+        receipts:
+          items:
+            $ref: "#/components/schemas/ReceiptDocument"
+          type: array
+        transactions:
+          items:
+            $ref: "#/components/schemas/ChunkTransactionWrapper"
+          type: array
+      required:
+        - author
+        - header
+        - receipts
+        - transactions
+      type: object
+    ChunkHeader:
+      additionalProperties: true
+      description: Chunk header object as served by neardata.
+      properties:
+        chunk_hash:
+          type: string
+        gas_limit:
+          type: integer
+        gas_used:
+          type: integer
+        height_created:
+          format: uint64
+          type: integer
+        height_included:
+          format: uint64
+          type: integer
+        outcome_root:
+          type: string
+        outgoing_receipts_root:
+          type: string
+        prev_block_hash:
+          type: string
+        shard_id:
+          format: uint64
+          type: integer
+        tx_root:
+          type: string
+      type: object
+    ChunkTransactionWrapper:
+      additionalProperties: false
+      description: Transaction entry returned inside a neardata chunk.
+      properties:
+        outcome:
+          $ref: "#/components/schemas/ExecutionWithReceipt"
+        transaction:
+          $ref: "#/components/schemas/SignedTransactionDocument"
+      required:
+        - outcome
+        - transaction
+      type: object
+    DataReceiptBody:
+      additionalProperties: false
+      properties:
+        Data:
+          $ref: "#/components/schemas/DataReceiptDocument"
+      required:
+        - Data
+      type: object
+    DataReceiptDocument:
+      additionalProperties: false
+      properties:
+        data:
+          type: string
+        data_id:
+          type: string
+        is_promise_resume:
+          type: boolean
+      required:
+        - data
+        - data_id
+        - is_promise_resume
+      type: object
+    ExecutionOutcomeDocument:
+      additionalProperties: false
+      properties:
+        block_hash:
+          type: string
+        id:
+          type: string
+        outcome:
+          $ref: "#/components/schemas/ExecutionOutcomeSummary"
+        proof:
+          items:
+            $ref: "#/components/schemas/ExecutionProofItem"
+          type: array
+      required:
+        - block_hash
+        - id
+        - outcome
+        - proof
+      type: object
+    ExecutionOutcomeStatus:
+      oneOf:
+        - $ref: "#/components/schemas/ExecutionOutcomeStatusSuccessReceiptId"
+        - $ref: "#/components/schemas/ExecutionOutcomeStatusSuccessValue"
+        - $ref: "#/components/schemas/ExecutionOutcomeStatusFailure"
+    ExecutionOutcomeStatusFailure:
+      additionalProperties: false
+      properties:
+        Failure:
+          additionalProperties: true
+          type: object
+      required:
+        - Failure
+      type: object
+    ExecutionOutcomeStatusSuccessReceiptId:
+      additionalProperties: false
+      properties:
+        SuccessReceiptId:
+          type: string
+      required:
+        - SuccessReceiptId
+      type: object
+    ExecutionOutcomeStatusSuccessValue:
+      additionalProperties: false
+      properties:
+        SuccessValue:
+          type: string
+      required:
+        - SuccessValue
+      type: object
+    ExecutionOutcomeSummary:
+      additionalProperties: false
+      properties:
+        executor_id:
+          type: string
+        gas_burnt:
+          format: uint64
+          type: integer
+        logs:
+          items:
+            type: string
+          type: array
+        metadata:
+          additionalProperties: true
+          type: object
+        receipt_ids:
+          items:
+            type: string
+          type: array
+        status:
+          $ref: "#/components/schemas/ExecutionOutcomeStatus"
+        tokens_burnt:
+          type: string
+      required:
+        - executor_id
+        - gas_burnt
+        - logs
+        - metadata
+        - receipt_ids
+        - status
+        - tokens_burnt
+      type: object
+    ExecutionProofItem:
+      additionalProperties: true
+      type: object
+    ExecutionWithReceipt:
+      additionalProperties: false
+      description: Execution result paired with an optional receipt object.
+      properties:
+        execution_outcome:
+          $ref: "#/components/schemas/ExecutionOutcomeDocument"
+        receipt:
+          description: Receipt payload when neardata includes it for this entry.
+          nullable: true
+          oneOf:
+            - $ref: "#/components/schemas/ReceiptDocument"
+            - $ref: "#/components/schemas/OmittedReceiptDocument"
+          type: object
+        tx_hash:
+          type: string
+      required:
+        - execution_outcome
+        - receipt
+      type: object
     HealthResponse:
       additionalProperties: false
       properties:
@@ -24,6 +317,226 @@ components:
           type: string
       required:
         - status
+      type: object
+    OmittedReceiptDocument:
+      additionalProperties: false
+      type: object
+    OutputDataReceiverDocument:
+      additionalProperties: false
+      properties:
+        data_id:
+          type: string
+        receiver_id:
+          type: string
+      required:
+        - data_id
+        - receiver_id
+      type: object
+    ReceiptBody:
+      oneOf:
+        - $ref: "#/components/schemas/ActionReceiptBody"
+        - $ref: "#/components/schemas/DataReceiptBody"
+    ReceiptDocument:
+      additionalProperties: false
+      description: Receipt object as served by neardata inside a chunk payload.
+      properties:
+        predecessor_id:
+          type: string
+        priority:
+          format: uint64
+          type: integer
+        receipt:
+          $ref: "#/components/schemas/ReceiptBody"
+        receipt_id:
+          type: string
+        receiver_id:
+          type: string
+      required:
+        - predecessor_id
+        - priority
+        - receipt
+        - receipt_id
+        - receiver_id
+      type: object
+    ShardDocument:
+      additionalProperties: false
+      description: Per-shard payload returned by neardata for a block.
+      properties:
+        chunk:
+          $ref: "#/components/schemas/ChunkDocument"
+        receipt_execution_outcomes:
+          items:
+            $ref: "#/components/schemas/ExecutionWithReceipt"
+          type: array
+        shard_id:
+          format: uint64
+          type: integer
+        state_changes:
+          items:
+            $ref: "#/components/schemas/StateChangeItem"
+          type: array
+      required:
+        - chunk
+        - receipt_execution_outcomes
+        - shard_id
+        - state_changes
+      type: object
+    SignedTransactionDocument:
+      additionalProperties: false
+      properties:
+        actions:
+          items:
+            $ref: "#/components/schemas/ActionDocument"
+          type: array
+        hash:
+          type: string
+        nonce:
+          format: uint64
+          type: integer
+        priority_fee:
+          format: uint64
+          type: integer
+        public_key:
+          type: string
+        receiver_id:
+          type: string
+        signature:
+          type: string
+        signer_id:
+          type: string
+      required:
+        - actions
+        - hash
+        - nonce
+        - priority_fee
+        - public_key
+        - receiver_id
+        - signature
+        - signer_id
+      type: object
+    StateChangeCause:
+      oneOf:
+        - $ref: "#/components/schemas/StateChangeCauseTransactionProcessing"
+        - $ref: "#/components/schemas/StateChangeCauseReceiptProcessing"
+        - $ref: "#/components/schemas/StateChangeCauseActionReceiptGasReward"
+    StateChangeCauseActionReceiptGasReward:
+      additionalProperties: false
+      properties:
+        receipt_hash:
+          type: string
+        type:
+          type: string
+      required:
+        - receipt_hash
+        - type
+      type: object
+    StateChangeCauseReceiptProcessing:
+      additionalProperties: false
+      properties:
+        receipt_hash:
+          type: string
+        type:
+          type: string
+      required:
+        - receipt_hash
+        - type
+      type: object
+    StateChangeCauseTransactionProcessing:
+      additionalProperties: false
+      properties:
+        tx_hash:
+          type: string
+        type:
+          type: string
+      required:
+        - tx_hash
+        - type
+      type: object
+    StateChangeItem:
+      additionalProperties: false
+      description: State change entry returned by neardata for a shard.
+      properties:
+        cause:
+          $ref: "#/components/schemas/StateChangeCause"
+        change:
+          $ref: "#/components/schemas/StateChangeValue"
+        type:
+          type: string
+      required:
+        - cause
+        - change
+        - type
+      type: object
+    StateChangeValue:
+      oneOf:
+        - $ref: "#/components/schemas/StateChangeValueAccountUpdate"
+        - $ref: "#/components/schemas/StateChangeValueAccessKeyUpdate"
+        - $ref: "#/components/schemas/StateChangeValueDataUpdate"
+        - $ref: "#/components/schemas/StateChangeValueDataDeletion"
+    StateChangeValueAccessKeyUpdate:
+      additionalProperties: false
+      properties:
+        access_key:
+          additionalProperties: true
+          type: object
+        account_id:
+          type: string
+        public_key:
+          type: string
+      required:
+        - access_key
+        - account_id
+        - public_key
+      type: object
+    StateChangeValueAccountUpdate:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        amount:
+          type: string
+        code_hash:
+          type: string
+        locked:
+          type: string
+        storage_paid_at:
+          format: uint64
+          type: integer
+        storage_usage:
+          format: uint64
+          type: integer
+      required:
+        - account_id
+        - amount
+        - code_hash
+        - locked
+        - storage_paid_at
+        - storage_usage
+      type: object
+    StateChangeValueDataDeletion:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        key_base64:
+          type: string
+      required:
+        - account_id
+        - key_base64
+      type: object
+    StateChangeValueDataUpdate:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        key_base64:
+          type: string
+        value_base64:
+          type: string
+      required:
+        - account_id
+        - key_base64
+        - value_base64
       type: object
 info:
   description: Cached and archived NEAR block data with redirect helpers for first-block and latest-block workflows. Some block-family routes may redirect depending on archive or freshness topology.
@@ -92,10 +605,8 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
-                description: Full block document as served by neardata, including `block` and `shards`.
+                $ref: "#/components/schemas/BlockDocument"
                 nullable: true
-                type: object
           description: Requested document, or `null` when the selected slice is absent
         "302":
           description: Redirect to a canonical archive or finalized block URL
@@ -160,10 +671,8 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
-                description: Chunk object for the requested shard ID.
+                $ref: "#/components/schemas/ChunkDocument"
                 nullable: true
-                type: object
           description: Requested document, or `null` when the selected slice is absent
         "302":
           description: Redirect to a canonical archive or finalized block URL
@@ -221,10 +730,8 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
-                description: Block-level object returned by `/headers`, corresponding to the full response's `block` field.
+                $ref: "#/components/schemas/BlockEnvelope"
                 nullable: true
-                type: object
           description: Requested document, or `null` when the selected slice is absent
         "302":
           description: Redirect to a canonical archive or finalized block URL
@@ -289,10 +796,8 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
-                description: Shard object for the requested shard ID.
+                $ref: "#/components/schemas/ShardDocument"
                 nullable: true
-                type: object
           description: Requested document, or `null` when the selected slice is absent
         "302":
           description: Redirect to a canonical archive or finalized block URL
@@ -350,10 +855,8 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
-                description: Full block document as served by neardata, including `block` and `shards`.
+                $ref: "#/components/schemas/BlockDocument"
                 nullable: true
-                type: object
           description: Requested document, or `null` when the selected slice is absent
         "302":
           description: Redirect to a canonical archive or finalized block URL
@@ -404,10 +907,8 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
-                description: Full block document as served by neardata, including `block` and `shards`.
+                $ref: "#/components/schemas/BlockDocument"
                 nullable: true
-                type: object
           description: Full block document returned after automatic redirect following
         "302":
           description: Redirect to the canonical first block URL
@@ -443,10 +944,8 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
-                description: Full block document as served by neardata, including `block` and `shards`.
+                $ref: "#/components/schemas/BlockDocument"
                 nullable: true
-                type: object
           description: Full block document returned after automatic redirect following
         "302":
           description: Redirect to the latest block block URL
@@ -488,10 +987,8 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
-                description: Full block document as served by neardata, including `block` and `shards`.
+                $ref: "#/components/schemas/BlockDocument"
                 nullable: true
-                type: object
           description: Full block document returned after automatic redirect following
         "302":
           description: Redirect to the latest block block URL

--- a/apis/neardata/system/health.yaml
+++ b/apis/neardata/system/health.yaml
@@ -47,6 +47,81 @@ servers:
     url: https://testnet.neardata.xyz
 components:
   schemas:
+    ActionDocument:
+      additionalProperties: true
+      type: object
+    ActionReceiptBody:
+      additionalProperties: false
+      properties:
+        Action:
+          $ref: "#/components/schemas/ActionReceiptDocument"
+      required:
+        - Action
+      type: object
+    ActionReceiptDocument:
+      additionalProperties: false
+      properties:
+        actions:
+          items:
+            $ref: "#/components/schemas/ActionDocument"
+          type: array
+        gas_price:
+          type: string
+        input_data_ids:
+          items:
+            type: string
+          type: array
+        is_promise_yield:
+          type: boolean
+        output_data_receivers:
+          items:
+            $ref: "#/components/schemas/OutputDataReceiverDocument"
+          type: array
+        signer_id:
+          type: string
+        signer_public_key:
+          type: string
+      required:
+        - actions
+        - gas_price
+        - input_data_ids
+        - is_promise_yield
+        - output_data_receivers
+        - signer_id
+        - signer_public_key
+      type: object
+    BlockDocument:
+      additionalProperties: false
+      description: Full block document as served by neardata, including the block envelope and per-shard payloads.
+      properties:
+        block:
+          $ref: "#/components/schemas/BlockEnvelope"
+        shards:
+          items:
+            $ref: "#/components/schemas/ShardDocument"
+          type: array
+      required:
+        - block
+        - shards
+      type: object
+    BlockEnvelope:
+      additionalProperties: false
+      description: Block-level payload returned by neardata.
+      properties:
+        author:
+          description: Block producer account ID.
+          type: string
+        chunks:
+          items:
+            $ref: "#/components/schemas/ChunkHeader"
+          type: array
+        header:
+          $ref: "#/components/schemas/BlockHeader"
+      required:
+        - author
+        - chunks
+        - header
+      type: object
     BlockErrorResponse:
       additionalProperties: false
       properties:
@@ -64,6 +139,224 @@ components:
         - BLOCK_HEIGHT_TOO_LOW
         - BLOCK_DOES_NOT_EXIST
       type: string
+    BlockHeader:
+      additionalProperties: true
+      description: Block header object as served by neardata.
+      properties:
+        chunks_included:
+          format: uint64
+          type: integer
+        epoch_id:
+          type: string
+        gas_price:
+          type: string
+        hash:
+          type: string
+        height:
+          format: uint64
+          type: integer
+        next_epoch_id:
+          type: string
+        prev_hash:
+          type: string
+        prev_height:
+          format: uint64
+          type: integer
+        timestamp:
+          type: integer
+        timestamp_nanosec:
+          type: string
+        total_supply:
+          type: string
+      type: object
+    ChunkDocument:
+      additionalProperties: false
+      description: Chunk payload returned by neardata for a single shard in a selected block.
+      properties:
+        author:
+          description: Chunk producer account ID.
+          type: string
+        header:
+          $ref: "#/components/schemas/ChunkHeader"
+        receipts:
+          items:
+            $ref: "#/components/schemas/ReceiptDocument"
+          type: array
+        transactions:
+          items:
+            $ref: "#/components/schemas/ChunkTransactionWrapper"
+          type: array
+      required:
+        - author
+        - header
+        - receipts
+        - transactions
+      type: object
+    ChunkHeader:
+      additionalProperties: true
+      description: Chunk header object as served by neardata.
+      properties:
+        chunk_hash:
+          type: string
+        gas_limit:
+          type: integer
+        gas_used:
+          type: integer
+        height_created:
+          format: uint64
+          type: integer
+        height_included:
+          format: uint64
+          type: integer
+        outcome_root:
+          type: string
+        outgoing_receipts_root:
+          type: string
+        prev_block_hash:
+          type: string
+        shard_id:
+          format: uint64
+          type: integer
+        tx_root:
+          type: string
+      type: object
+    ChunkTransactionWrapper:
+      additionalProperties: false
+      description: Transaction entry returned inside a neardata chunk.
+      properties:
+        outcome:
+          $ref: "#/components/schemas/ExecutionWithReceipt"
+        transaction:
+          $ref: "#/components/schemas/SignedTransactionDocument"
+      required:
+        - outcome
+        - transaction
+      type: object
+    DataReceiptBody:
+      additionalProperties: false
+      properties:
+        Data:
+          $ref: "#/components/schemas/DataReceiptDocument"
+      required:
+        - Data
+      type: object
+    DataReceiptDocument:
+      additionalProperties: false
+      properties:
+        data:
+          type: string
+        data_id:
+          type: string
+        is_promise_resume:
+          type: boolean
+      required:
+        - data
+        - data_id
+        - is_promise_resume
+      type: object
+    ExecutionOutcomeDocument:
+      additionalProperties: false
+      properties:
+        block_hash:
+          type: string
+        id:
+          type: string
+        outcome:
+          $ref: "#/components/schemas/ExecutionOutcomeSummary"
+        proof:
+          items:
+            $ref: "#/components/schemas/ExecutionProofItem"
+          type: array
+      required:
+        - block_hash
+        - id
+        - outcome
+        - proof
+      type: object
+    ExecutionOutcomeStatus:
+      oneOf:
+        - $ref: "#/components/schemas/ExecutionOutcomeStatusSuccessReceiptId"
+        - $ref: "#/components/schemas/ExecutionOutcomeStatusSuccessValue"
+        - $ref: "#/components/schemas/ExecutionOutcomeStatusFailure"
+    ExecutionOutcomeStatusFailure:
+      additionalProperties: false
+      properties:
+        Failure:
+          additionalProperties: true
+          type: object
+      required:
+        - Failure
+      type: object
+    ExecutionOutcomeStatusSuccessReceiptId:
+      additionalProperties: false
+      properties:
+        SuccessReceiptId:
+          type: string
+      required:
+        - SuccessReceiptId
+      type: object
+    ExecutionOutcomeStatusSuccessValue:
+      additionalProperties: false
+      properties:
+        SuccessValue:
+          type: string
+      required:
+        - SuccessValue
+      type: object
+    ExecutionOutcomeSummary:
+      additionalProperties: false
+      properties:
+        executor_id:
+          type: string
+        gas_burnt:
+          format: uint64
+          type: integer
+        logs:
+          items:
+            type: string
+          type: array
+        metadata:
+          additionalProperties: true
+          type: object
+        receipt_ids:
+          items:
+            type: string
+          type: array
+        status:
+          $ref: "#/components/schemas/ExecutionOutcomeStatus"
+        tokens_burnt:
+          type: string
+      required:
+        - executor_id
+        - gas_burnt
+        - logs
+        - metadata
+        - receipt_ids
+        - status
+        - tokens_burnt
+      type: object
+    ExecutionProofItem:
+      additionalProperties: true
+      type: object
+    ExecutionWithReceipt:
+      additionalProperties: false
+      description: Execution result paired with an optional receipt object.
+      properties:
+        execution_outcome:
+          $ref: "#/components/schemas/ExecutionOutcomeDocument"
+        receipt:
+          description: Receipt payload when neardata includes it for this entry.
+          nullable: true
+          oneOf:
+            - $ref: "#/components/schemas/ReceiptDocument"
+            - $ref: "#/components/schemas/OmittedReceiptDocument"
+          type: object
+        tx_hash:
+          type: string
+      required:
+        - execution_outcome
+        - receipt
+      type: object
     HealthResponse:
       additionalProperties: false
       properties:
@@ -71,4 +364,224 @@ components:
           type: string
       required:
         - status
+      type: object
+    OmittedReceiptDocument:
+      additionalProperties: false
+      type: object
+    OutputDataReceiverDocument:
+      additionalProperties: false
+      properties:
+        data_id:
+          type: string
+        receiver_id:
+          type: string
+      required:
+        - data_id
+        - receiver_id
+      type: object
+    ReceiptBody:
+      oneOf:
+        - $ref: "#/components/schemas/ActionReceiptBody"
+        - $ref: "#/components/schemas/DataReceiptBody"
+    ReceiptDocument:
+      additionalProperties: false
+      description: Receipt object as served by neardata inside a chunk payload.
+      properties:
+        predecessor_id:
+          type: string
+        priority:
+          format: uint64
+          type: integer
+        receipt:
+          $ref: "#/components/schemas/ReceiptBody"
+        receipt_id:
+          type: string
+        receiver_id:
+          type: string
+      required:
+        - predecessor_id
+        - priority
+        - receipt
+        - receipt_id
+        - receiver_id
+      type: object
+    ShardDocument:
+      additionalProperties: false
+      description: Per-shard payload returned by neardata for a block.
+      properties:
+        chunk:
+          $ref: "#/components/schemas/ChunkDocument"
+        receipt_execution_outcomes:
+          items:
+            $ref: "#/components/schemas/ExecutionWithReceipt"
+          type: array
+        shard_id:
+          format: uint64
+          type: integer
+        state_changes:
+          items:
+            $ref: "#/components/schemas/StateChangeItem"
+          type: array
+      required:
+        - chunk
+        - receipt_execution_outcomes
+        - shard_id
+        - state_changes
+      type: object
+    SignedTransactionDocument:
+      additionalProperties: false
+      properties:
+        actions:
+          items:
+            $ref: "#/components/schemas/ActionDocument"
+          type: array
+        hash:
+          type: string
+        nonce:
+          format: uint64
+          type: integer
+        priority_fee:
+          format: uint64
+          type: integer
+        public_key:
+          type: string
+        receiver_id:
+          type: string
+        signature:
+          type: string
+        signer_id:
+          type: string
+      required:
+        - actions
+        - hash
+        - nonce
+        - priority_fee
+        - public_key
+        - receiver_id
+        - signature
+        - signer_id
+      type: object
+    StateChangeCause:
+      oneOf:
+        - $ref: "#/components/schemas/StateChangeCauseTransactionProcessing"
+        - $ref: "#/components/schemas/StateChangeCauseReceiptProcessing"
+        - $ref: "#/components/schemas/StateChangeCauseActionReceiptGasReward"
+    StateChangeCauseActionReceiptGasReward:
+      additionalProperties: false
+      properties:
+        receipt_hash:
+          type: string
+        type:
+          type: string
+      required:
+        - receipt_hash
+        - type
+      type: object
+    StateChangeCauseReceiptProcessing:
+      additionalProperties: false
+      properties:
+        receipt_hash:
+          type: string
+        type:
+          type: string
+      required:
+        - receipt_hash
+        - type
+      type: object
+    StateChangeCauseTransactionProcessing:
+      additionalProperties: false
+      properties:
+        tx_hash:
+          type: string
+        type:
+          type: string
+      required:
+        - tx_hash
+        - type
+      type: object
+    StateChangeItem:
+      additionalProperties: false
+      description: State change entry returned by neardata for a shard.
+      properties:
+        cause:
+          $ref: "#/components/schemas/StateChangeCause"
+        change:
+          $ref: "#/components/schemas/StateChangeValue"
+        type:
+          type: string
+      required:
+        - cause
+        - change
+        - type
+      type: object
+    StateChangeValue:
+      oneOf:
+        - $ref: "#/components/schemas/StateChangeValueAccountUpdate"
+        - $ref: "#/components/schemas/StateChangeValueAccessKeyUpdate"
+        - $ref: "#/components/schemas/StateChangeValueDataUpdate"
+        - $ref: "#/components/schemas/StateChangeValueDataDeletion"
+    StateChangeValueAccessKeyUpdate:
+      additionalProperties: false
+      properties:
+        access_key:
+          additionalProperties: true
+          type: object
+        account_id:
+          type: string
+        public_key:
+          type: string
+      required:
+        - access_key
+        - account_id
+        - public_key
+      type: object
+    StateChangeValueAccountUpdate:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        amount:
+          type: string
+        code_hash:
+          type: string
+        locked:
+          type: string
+        storage_paid_at:
+          format: uint64
+          type: integer
+        storage_usage:
+          format: uint64
+          type: integer
+      required:
+        - account_id
+        - amount
+        - code_hash
+        - locked
+        - storage_paid_at
+        - storage_usage
+      type: object
+    StateChangeValueDataDeletion:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        key_base64:
+          type: string
+      required:
+        - account_id
+        - key_base64
+      type: object
+    StateChangeValueDataUpdate:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        key_base64:
+          type: string
+        value_base64:
+          type: string
+      required:
+        - account_id
+        - key_base64
+        - value_base64
       type: object

--- a/apis/neardata/v0/block.yaml
+++ b/apis/neardata/v0/block.yaml
@@ -27,10 +27,8 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
-                description: Full block document as served by neardata, including `block` and `shards`.
+                $ref: "#/components/schemas/BlockDocument"
                 nullable: true
-                type: object
           description: Requested document, or `null` when the selected slice is absent
         "302":
           description: Redirect to a canonical archive or finalized block URL
@@ -70,6 +68,81 @@ servers:
     url: https://testnet.neardata.xyz
 components:
   schemas:
+    ActionDocument:
+      additionalProperties: true
+      type: object
+    ActionReceiptBody:
+      additionalProperties: false
+      properties:
+        Action:
+          $ref: "#/components/schemas/ActionReceiptDocument"
+      required:
+        - Action
+      type: object
+    ActionReceiptDocument:
+      additionalProperties: false
+      properties:
+        actions:
+          items:
+            $ref: "#/components/schemas/ActionDocument"
+          type: array
+        gas_price:
+          type: string
+        input_data_ids:
+          items:
+            type: string
+          type: array
+        is_promise_yield:
+          type: boolean
+        output_data_receivers:
+          items:
+            $ref: "#/components/schemas/OutputDataReceiverDocument"
+          type: array
+        signer_id:
+          type: string
+        signer_public_key:
+          type: string
+      required:
+        - actions
+        - gas_price
+        - input_data_ids
+        - is_promise_yield
+        - output_data_receivers
+        - signer_id
+        - signer_public_key
+      type: object
+    BlockDocument:
+      additionalProperties: false
+      description: Full block document as served by neardata, including the block envelope and per-shard payloads.
+      properties:
+        block:
+          $ref: "#/components/schemas/BlockEnvelope"
+        shards:
+          items:
+            $ref: "#/components/schemas/ShardDocument"
+          type: array
+      required:
+        - block
+        - shards
+      type: object
+    BlockEnvelope:
+      additionalProperties: false
+      description: Block-level payload returned by neardata.
+      properties:
+        author:
+          description: Block producer account ID.
+          type: string
+        chunks:
+          items:
+            $ref: "#/components/schemas/ChunkHeader"
+          type: array
+        header:
+          $ref: "#/components/schemas/BlockHeader"
+      required:
+        - author
+        - chunks
+        - header
+      type: object
     BlockErrorResponse:
       additionalProperties: false
       properties:
@@ -87,6 +160,224 @@ components:
         - BLOCK_HEIGHT_TOO_LOW
         - BLOCK_DOES_NOT_EXIST
       type: string
+    BlockHeader:
+      additionalProperties: true
+      description: Block header object as served by neardata.
+      properties:
+        chunks_included:
+          format: uint64
+          type: integer
+        epoch_id:
+          type: string
+        gas_price:
+          type: string
+        hash:
+          type: string
+        height:
+          format: uint64
+          type: integer
+        next_epoch_id:
+          type: string
+        prev_hash:
+          type: string
+        prev_height:
+          format: uint64
+          type: integer
+        timestamp:
+          type: integer
+        timestamp_nanosec:
+          type: string
+        total_supply:
+          type: string
+      type: object
+    ChunkDocument:
+      additionalProperties: false
+      description: Chunk payload returned by neardata for a single shard in a selected block.
+      properties:
+        author:
+          description: Chunk producer account ID.
+          type: string
+        header:
+          $ref: "#/components/schemas/ChunkHeader"
+        receipts:
+          items:
+            $ref: "#/components/schemas/ReceiptDocument"
+          type: array
+        transactions:
+          items:
+            $ref: "#/components/schemas/ChunkTransactionWrapper"
+          type: array
+      required:
+        - author
+        - header
+        - receipts
+        - transactions
+      type: object
+    ChunkHeader:
+      additionalProperties: true
+      description: Chunk header object as served by neardata.
+      properties:
+        chunk_hash:
+          type: string
+        gas_limit:
+          type: integer
+        gas_used:
+          type: integer
+        height_created:
+          format: uint64
+          type: integer
+        height_included:
+          format: uint64
+          type: integer
+        outcome_root:
+          type: string
+        outgoing_receipts_root:
+          type: string
+        prev_block_hash:
+          type: string
+        shard_id:
+          format: uint64
+          type: integer
+        tx_root:
+          type: string
+      type: object
+    ChunkTransactionWrapper:
+      additionalProperties: false
+      description: Transaction entry returned inside a neardata chunk.
+      properties:
+        outcome:
+          $ref: "#/components/schemas/ExecutionWithReceipt"
+        transaction:
+          $ref: "#/components/schemas/SignedTransactionDocument"
+      required:
+        - outcome
+        - transaction
+      type: object
+    DataReceiptBody:
+      additionalProperties: false
+      properties:
+        Data:
+          $ref: "#/components/schemas/DataReceiptDocument"
+      required:
+        - Data
+      type: object
+    DataReceiptDocument:
+      additionalProperties: false
+      properties:
+        data:
+          type: string
+        data_id:
+          type: string
+        is_promise_resume:
+          type: boolean
+      required:
+        - data
+        - data_id
+        - is_promise_resume
+      type: object
+    ExecutionOutcomeDocument:
+      additionalProperties: false
+      properties:
+        block_hash:
+          type: string
+        id:
+          type: string
+        outcome:
+          $ref: "#/components/schemas/ExecutionOutcomeSummary"
+        proof:
+          items:
+            $ref: "#/components/schemas/ExecutionProofItem"
+          type: array
+      required:
+        - block_hash
+        - id
+        - outcome
+        - proof
+      type: object
+    ExecutionOutcomeStatus:
+      oneOf:
+        - $ref: "#/components/schemas/ExecutionOutcomeStatusSuccessReceiptId"
+        - $ref: "#/components/schemas/ExecutionOutcomeStatusSuccessValue"
+        - $ref: "#/components/schemas/ExecutionOutcomeStatusFailure"
+    ExecutionOutcomeStatusFailure:
+      additionalProperties: false
+      properties:
+        Failure:
+          additionalProperties: true
+          type: object
+      required:
+        - Failure
+      type: object
+    ExecutionOutcomeStatusSuccessReceiptId:
+      additionalProperties: false
+      properties:
+        SuccessReceiptId:
+          type: string
+      required:
+        - SuccessReceiptId
+      type: object
+    ExecutionOutcomeStatusSuccessValue:
+      additionalProperties: false
+      properties:
+        SuccessValue:
+          type: string
+      required:
+        - SuccessValue
+      type: object
+    ExecutionOutcomeSummary:
+      additionalProperties: false
+      properties:
+        executor_id:
+          type: string
+        gas_burnt:
+          format: uint64
+          type: integer
+        logs:
+          items:
+            type: string
+          type: array
+        metadata:
+          additionalProperties: true
+          type: object
+        receipt_ids:
+          items:
+            type: string
+          type: array
+        status:
+          $ref: "#/components/schemas/ExecutionOutcomeStatus"
+        tokens_burnt:
+          type: string
+      required:
+        - executor_id
+        - gas_burnt
+        - logs
+        - metadata
+        - receipt_ids
+        - status
+        - tokens_burnt
+      type: object
+    ExecutionProofItem:
+      additionalProperties: true
+      type: object
+    ExecutionWithReceipt:
+      additionalProperties: false
+      description: Execution result paired with an optional receipt object.
+      properties:
+        execution_outcome:
+          $ref: "#/components/schemas/ExecutionOutcomeDocument"
+        receipt:
+          description: Receipt payload when neardata includes it for this entry.
+          nullable: true
+          oneOf:
+            - $ref: "#/components/schemas/ReceiptDocument"
+            - $ref: "#/components/schemas/OmittedReceiptDocument"
+          type: object
+        tx_hash:
+          type: string
+      required:
+        - execution_outcome
+        - receipt
+      type: object
     HealthResponse:
       additionalProperties: false
       properties:
@@ -94,4 +385,224 @@ components:
           type: string
       required:
         - status
+      type: object
+    OmittedReceiptDocument:
+      additionalProperties: false
+      type: object
+    OutputDataReceiverDocument:
+      additionalProperties: false
+      properties:
+        data_id:
+          type: string
+        receiver_id:
+          type: string
+      required:
+        - data_id
+        - receiver_id
+      type: object
+    ReceiptBody:
+      oneOf:
+        - $ref: "#/components/schemas/ActionReceiptBody"
+        - $ref: "#/components/schemas/DataReceiptBody"
+    ReceiptDocument:
+      additionalProperties: false
+      description: Receipt object as served by neardata inside a chunk payload.
+      properties:
+        predecessor_id:
+          type: string
+        priority:
+          format: uint64
+          type: integer
+        receipt:
+          $ref: "#/components/schemas/ReceiptBody"
+        receipt_id:
+          type: string
+        receiver_id:
+          type: string
+      required:
+        - predecessor_id
+        - priority
+        - receipt
+        - receipt_id
+        - receiver_id
+      type: object
+    ShardDocument:
+      additionalProperties: false
+      description: Per-shard payload returned by neardata for a block.
+      properties:
+        chunk:
+          $ref: "#/components/schemas/ChunkDocument"
+        receipt_execution_outcomes:
+          items:
+            $ref: "#/components/schemas/ExecutionWithReceipt"
+          type: array
+        shard_id:
+          format: uint64
+          type: integer
+        state_changes:
+          items:
+            $ref: "#/components/schemas/StateChangeItem"
+          type: array
+      required:
+        - chunk
+        - receipt_execution_outcomes
+        - shard_id
+        - state_changes
+      type: object
+    SignedTransactionDocument:
+      additionalProperties: false
+      properties:
+        actions:
+          items:
+            $ref: "#/components/schemas/ActionDocument"
+          type: array
+        hash:
+          type: string
+        nonce:
+          format: uint64
+          type: integer
+        priority_fee:
+          format: uint64
+          type: integer
+        public_key:
+          type: string
+        receiver_id:
+          type: string
+        signature:
+          type: string
+        signer_id:
+          type: string
+      required:
+        - actions
+        - hash
+        - nonce
+        - priority_fee
+        - public_key
+        - receiver_id
+        - signature
+        - signer_id
+      type: object
+    StateChangeCause:
+      oneOf:
+        - $ref: "#/components/schemas/StateChangeCauseTransactionProcessing"
+        - $ref: "#/components/schemas/StateChangeCauseReceiptProcessing"
+        - $ref: "#/components/schemas/StateChangeCauseActionReceiptGasReward"
+    StateChangeCauseActionReceiptGasReward:
+      additionalProperties: false
+      properties:
+        receipt_hash:
+          type: string
+        type:
+          type: string
+      required:
+        - receipt_hash
+        - type
+      type: object
+    StateChangeCauseReceiptProcessing:
+      additionalProperties: false
+      properties:
+        receipt_hash:
+          type: string
+        type:
+          type: string
+      required:
+        - receipt_hash
+        - type
+      type: object
+    StateChangeCauseTransactionProcessing:
+      additionalProperties: false
+      properties:
+        tx_hash:
+          type: string
+        type:
+          type: string
+      required:
+        - tx_hash
+        - type
+      type: object
+    StateChangeItem:
+      additionalProperties: false
+      description: State change entry returned by neardata for a shard.
+      properties:
+        cause:
+          $ref: "#/components/schemas/StateChangeCause"
+        change:
+          $ref: "#/components/schemas/StateChangeValue"
+        type:
+          type: string
+      required:
+        - cause
+        - change
+        - type
+      type: object
+    StateChangeValue:
+      oneOf:
+        - $ref: "#/components/schemas/StateChangeValueAccountUpdate"
+        - $ref: "#/components/schemas/StateChangeValueAccessKeyUpdate"
+        - $ref: "#/components/schemas/StateChangeValueDataUpdate"
+        - $ref: "#/components/schemas/StateChangeValueDataDeletion"
+    StateChangeValueAccessKeyUpdate:
+      additionalProperties: false
+      properties:
+        access_key:
+          additionalProperties: true
+          type: object
+        account_id:
+          type: string
+        public_key:
+          type: string
+      required:
+        - access_key
+        - account_id
+        - public_key
+      type: object
+    StateChangeValueAccountUpdate:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        amount:
+          type: string
+        code_hash:
+          type: string
+        locked:
+          type: string
+        storage_paid_at:
+          format: uint64
+          type: integer
+        storage_usage:
+          format: uint64
+          type: integer
+      required:
+        - account_id
+        - amount
+        - code_hash
+        - locked
+        - storage_paid_at
+        - storage_usage
+      type: object
+    StateChangeValueDataDeletion:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        key_base64:
+          type: string
+      required:
+        - account_id
+        - key_base64
+      type: object
+    StateChangeValueDataUpdate:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        key_base64:
+          type: string
+        value_base64:
+          type: string
+      required:
+        - account_id
+        - key_base64
+        - value_base64
       type: object

--- a/apis/neardata/v0/block_chunk.yaml
+++ b/apis/neardata/v0/block_chunk.yaml
@@ -34,10 +34,8 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
-                description: Chunk object for the requested shard ID.
+                $ref: "#/components/schemas/ChunkDocument"
                 nullable: true
-                type: object
           description: Requested document, or `null` when the selected slice is absent
         "302":
           description: Redirect to a canonical archive or finalized block URL
@@ -77,6 +75,81 @@ servers:
     url: https://testnet.neardata.xyz
 components:
   schemas:
+    ActionDocument:
+      additionalProperties: true
+      type: object
+    ActionReceiptBody:
+      additionalProperties: false
+      properties:
+        Action:
+          $ref: "#/components/schemas/ActionReceiptDocument"
+      required:
+        - Action
+      type: object
+    ActionReceiptDocument:
+      additionalProperties: false
+      properties:
+        actions:
+          items:
+            $ref: "#/components/schemas/ActionDocument"
+          type: array
+        gas_price:
+          type: string
+        input_data_ids:
+          items:
+            type: string
+          type: array
+        is_promise_yield:
+          type: boolean
+        output_data_receivers:
+          items:
+            $ref: "#/components/schemas/OutputDataReceiverDocument"
+          type: array
+        signer_id:
+          type: string
+        signer_public_key:
+          type: string
+      required:
+        - actions
+        - gas_price
+        - input_data_ids
+        - is_promise_yield
+        - output_data_receivers
+        - signer_id
+        - signer_public_key
+      type: object
+    BlockDocument:
+      additionalProperties: false
+      description: Full block document as served by neardata, including the block envelope and per-shard payloads.
+      properties:
+        block:
+          $ref: "#/components/schemas/BlockEnvelope"
+        shards:
+          items:
+            $ref: "#/components/schemas/ShardDocument"
+          type: array
+      required:
+        - block
+        - shards
+      type: object
+    BlockEnvelope:
+      additionalProperties: false
+      description: Block-level payload returned by neardata.
+      properties:
+        author:
+          description: Block producer account ID.
+          type: string
+        chunks:
+          items:
+            $ref: "#/components/schemas/ChunkHeader"
+          type: array
+        header:
+          $ref: "#/components/schemas/BlockHeader"
+      required:
+        - author
+        - chunks
+        - header
+      type: object
     BlockErrorResponse:
       additionalProperties: false
       properties:
@@ -94,6 +167,224 @@ components:
         - BLOCK_HEIGHT_TOO_LOW
         - BLOCK_DOES_NOT_EXIST
       type: string
+    BlockHeader:
+      additionalProperties: true
+      description: Block header object as served by neardata.
+      properties:
+        chunks_included:
+          format: uint64
+          type: integer
+        epoch_id:
+          type: string
+        gas_price:
+          type: string
+        hash:
+          type: string
+        height:
+          format: uint64
+          type: integer
+        next_epoch_id:
+          type: string
+        prev_hash:
+          type: string
+        prev_height:
+          format: uint64
+          type: integer
+        timestamp:
+          type: integer
+        timestamp_nanosec:
+          type: string
+        total_supply:
+          type: string
+      type: object
+    ChunkDocument:
+      additionalProperties: false
+      description: Chunk payload returned by neardata for a single shard in a selected block.
+      properties:
+        author:
+          description: Chunk producer account ID.
+          type: string
+        header:
+          $ref: "#/components/schemas/ChunkHeader"
+        receipts:
+          items:
+            $ref: "#/components/schemas/ReceiptDocument"
+          type: array
+        transactions:
+          items:
+            $ref: "#/components/schemas/ChunkTransactionWrapper"
+          type: array
+      required:
+        - author
+        - header
+        - receipts
+        - transactions
+      type: object
+    ChunkHeader:
+      additionalProperties: true
+      description: Chunk header object as served by neardata.
+      properties:
+        chunk_hash:
+          type: string
+        gas_limit:
+          type: integer
+        gas_used:
+          type: integer
+        height_created:
+          format: uint64
+          type: integer
+        height_included:
+          format: uint64
+          type: integer
+        outcome_root:
+          type: string
+        outgoing_receipts_root:
+          type: string
+        prev_block_hash:
+          type: string
+        shard_id:
+          format: uint64
+          type: integer
+        tx_root:
+          type: string
+      type: object
+    ChunkTransactionWrapper:
+      additionalProperties: false
+      description: Transaction entry returned inside a neardata chunk.
+      properties:
+        outcome:
+          $ref: "#/components/schemas/ExecutionWithReceipt"
+        transaction:
+          $ref: "#/components/schemas/SignedTransactionDocument"
+      required:
+        - outcome
+        - transaction
+      type: object
+    DataReceiptBody:
+      additionalProperties: false
+      properties:
+        Data:
+          $ref: "#/components/schemas/DataReceiptDocument"
+      required:
+        - Data
+      type: object
+    DataReceiptDocument:
+      additionalProperties: false
+      properties:
+        data:
+          type: string
+        data_id:
+          type: string
+        is_promise_resume:
+          type: boolean
+      required:
+        - data
+        - data_id
+        - is_promise_resume
+      type: object
+    ExecutionOutcomeDocument:
+      additionalProperties: false
+      properties:
+        block_hash:
+          type: string
+        id:
+          type: string
+        outcome:
+          $ref: "#/components/schemas/ExecutionOutcomeSummary"
+        proof:
+          items:
+            $ref: "#/components/schemas/ExecutionProofItem"
+          type: array
+      required:
+        - block_hash
+        - id
+        - outcome
+        - proof
+      type: object
+    ExecutionOutcomeStatus:
+      oneOf:
+        - $ref: "#/components/schemas/ExecutionOutcomeStatusSuccessReceiptId"
+        - $ref: "#/components/schemas/ExecutionOutcomeStatusSuccessValue"
+        - $ref: "#/components/schemas/ExecutionOutcomeStatusFailure"
+    ExecutionOutcomeStatusFailure:
+      additionalProperties: false
+      properties:
+        Failure:
+          additionalProperties: true
+          type: object
+      required:
+        - Failure
+      type: object
+    ExecutionOutcomeStatusSuccessReceiptId:
+      additionalProperties: false
+      properties:
+        SuccessReceiptId:
+          type: string
+      required:
+        - SuccessReceiptId
+      type: object
+    ExecutionOutcomeStatusSuccessValue:
+      additionalProperties: false
+      properties:
+        SuccessValue:
+          type: string
+      required:
+        - SuccessValue
+      type: object
+    ExecutionOutcomeSummary:
+      additionalProperties: false
+      properties:
+        executor_id:
+          type: string
+        gas_burnt:
+          format: uint64
+          type: integer
+        logs:
+          items:
+            type: string
+          type: array
+        metadata:
+          additionalProperties: true
+          type: object
+        receipt_ids:
+          items:
+            type: string
+          type: array
+        status:
+          $ref: "#/components/schemas/ExecutionOutcomeStatus"
+        tokens_burnt:
+          type: string
+      required:
+        - executor_id
+        - gas_burnt
+        - logs
+        - metadata
+        - receipt_ids
+        - status
+        - tokens_burnt
+      type: object
+    ExecutionProofItem:
+      additionalProperties: true
+      type: object
+    ExecutionWithReceipt:
+      additionalProperties: false
+      description: Execution result paired with an optional receipt object.
+      properties:
+        execution_outcome:
+          $ref: "#/components/schemas/ExecutionOutcomeDocument"
+        receipt:
+          description: Receipt payload when neardata includes it for this entry.
+          nullable: true
+          oneOf:
+            - $ref: "#/components/schemas/ReceiptDocument"
+            - $ref: "#/components/schemas/OmittedReceiptDocument"
+          type: object
+        tx_hash:
+          type: string
+      required:
+        - execution_outcome
+        - receipt
+      type: object
     HealthResponse:
       additionalProperties: false
       properties:
@@ -101,4 +392,224 @@ components:
           type: string
       required:
         - status
+      type: object
+    OmittedReceiptDocument:
+      additionalProperties: false
+      type: object
+    OutputDataReceiverDocument:
+      additionalProperties: false
+      properties:
+        data_id:
+          type: string
+        receiver_id:
+          type: string
+      required:
+        - data_id
+        - receiver_id
+      type: object
+    ReceiptBody:
+      oneOf:
+        - $ref: "#/components/schemas/ActionReceiptBody"
+        - $ref: "#/components/schemas/DataReceiptBody"
+    ReceiptDocument:
+      additionalProperties: false
+      description: Receipt object as served by neardata inside a chunk payload.
+      properties:
+        predecessor_id:
+          type: string
+        priority:
+          format: uint64
+          type: integer
+        receipt:
+          $ref: "#/components/schemas/ReceiptBody"
+        receipt_id:
+          type: string
+        receiver_id:
+          type: string
+      required:
+        - predecessor_id
+        - priority
+        - receipt
+        - receipt_id
+        - receiver_id
+      type: object
+    ShardDocument:
+      additionalProperties: false
+      description: Per-shard payload returned by neardata for a block.
+      properties:
+        chunk:
+          $ref: "#/components/schemas/ChunkDocument"
+        receipt_execution_outcomes:
+          items:
+            $ref: "#/components/schemas/ExecutionWithReceipt"
+          type: array
+        shard_id:
+          format: uint64
+          type: integer
+        state_changes:
+          items:
+            $ref: "#/components/schemas/StateChangeItem"
+          type: array
+      required:
+        - chunk
+        - receipt_execution_outcomes
+        - shard_id
+        - state_changes
+      type: object
+    SignedTransactionDocument:
+      additionalProperties: false
+      properties:
+        actions:
+          items:
+            $ref: "#/components/schemas/ActionDocument"
+          type: array
+        hash:
+          type: string
+        nonce:
+          format: uint64
+          type: integer
+        priority_fee:
+          format: uint64
+          type: integer
+        public_key:
+          type: string
+        receiver_id:
+          type: string
+        signature:
+          type: string
+        signer_id:
+          type: string
+      required:
+        - actions
+        - hash
+        - nonce
+        - priority_fee
+        - public_key
+        - receiver_id
+        - signature
+        - signer_id
+      type: object
+    StateChangeCause:
+      oneOf:
+        - $ref: "#/components/schemas/StateChangeCauseTransactionProcessing"
+        - $ref: "#/components/schemas/StateChangeCauseReceiptProcessing"
+        - $ref: "#/components/schemas/StateChangeCauseActionReceiptGasReward"
+    StateChangeCauseActionReceiptGasReward:
+      additionalProperties: false
+      properties:
+        receipt_hash:
+          type: string
+        type:
+          type: string
+      required:
+        - receipt_hash
+        - type
+      type: object
+    StateChangeCauseReceiptProcessing:
+      additionalProperties: false
+      properties:
+        receipt_hash:
+          type: string
+        type:
+          type: string
+      required:
+        - receipt_hash
+        - type
+      type: object
+    StateChangeCauseTransactionProcessing:
+      additionalProperties: false
+      properties:
+        tx_hash:
+          type: string
+        type:
+          type: string
+      required:
+        - tx_hash
+        - type
+      type: object
+    StateChangeItem:
+      additionalProperties: false
+      description: State change entry returned by neardata for a shard.
+      properties:
+        cause:
+          $ref: "#/components/schemas/StateChangeCause"
+        change:
+          $ref: "#/components/schemas/StateChangeValue"
+        type:
+          type: string
+      required:
+        - cause
+        - change
+        - type
+      type: object
+    StateChangeValue:
+      oneOf:
+        - $ref: "#/components/schemas/StateChangeValueAccountUpdate"
+        - $ref: "#/components/schemas/StateChangeValueAccessKeyUpdate"
+        - $ref: "#/components/schemas/StateChangeValueDataUpdate"
+        - $ref: "#/components/schemas/StateChangeValueDataDeletion"
+    StateChangeValueAccessKeyUpdate:
+      additionalProperties: false
+      properties:
+        access_key:
+          additionalProperties: true
+          type: object
+        account_id:
+          type: string
+        public_key:
+          type: string
+      required:
+        - access_key
+        - account_id
+        - public_key
+      type: object
+    StateChangeValueAccountUpdate:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        amount:
+          type: string
+        code_hash:
+          type: string
+        locked:
+          type: string
+        storage_paid_at:
+          format: uint64
+          type: integer
+        storage_usage:
+          format: uint64
+          type: integer
+      required:
+        - account_id
+        - amount
+        - code_hash
+        - locked
+        - storage_paid_at
+        - storage_usage
+      type: object
+    StateChangeValueDataDeletion:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        key_base64:
+          type: string
+      required:
+        - account_id
+        - key_base64
+      type: object
+    StateChangeValueDataUpdate:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        key_base64:
+          type: string
+        value_base64:
+          type: string
+      required:
+        - account_id
+        - key_base64
+        - value_base64
       type: object

--- a/apis/neardata/v0/block_headers.yaml
+++ b/apis/neardata/v0/block_headers.yaml
@@ -27,10 +27,8 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
-                description: Block-level object returned by `/headers`, corresponding to the full response's `block` field.
+                $ref: "#/components/schemas/BlockEnvelope"
                 nullable: true
-                type: object
           description: Requested document, or `null` when the selected slice is absent
         "302":
           description: Redirect to a canonical archive or finalized block URL
@@ -70,6 +68,81 @@ servers:
     url: https://testnet.neardata.xyz
 components:
   schemas:
+    ActionDocument:
+      additionalProperties: true
+      type: object
+    ActionReceiptBody:
+      additionalProperties: false
+      properties:
+        Action:
+          $ref: "#/components/schemas/ActionReceiptDocument"
+      required:
+        - Action
+      type: object
+    ActionReceiptDocument:
+      additionalProperties: false
+      properties:
+        actions:
+          items:
+            $ref: "#/components/schemas/ActionDocument"
+          type: array
+        gas_price:
+          type: string
+        input_data_ids:
+          items:
+            type: string
+          type: array
+        is_promise_yield:
+          type: boolean
+        output_data_receivers:
+          items:
+            $ref: "#/components/schemas/OutputDataReceiverDocument"
+          type: array
+        signer_id:
+          type: string
+        signer_public_key:
+          type: string
+      required:
+        - actions
+        - gas_price
+        - input_data_ids
+        - is_promise_yield
+        - output_data_receivers
+        - signer_id
+        - signer_public_key
+      type: object
+    BlockDocument:
+      additionalProperties: false
+      description: Full block document as served by neardata, including the block envelope and per-shard payloads.
+      properties:
+        block:
+          $ref: "#/components/schemas/BlockEnvelope"
+        shards:
+          items:
+            $ref: "#/components/schemas/ShardDocument"
+          type: array
+      required:
+        - block
+        - shards
+      type: object
+    BlockEnvelope:
+      additionalProperties: false
+      description: Block-level payload returned by neardata.
+      properties:
+        author:
+          description: Block producer account ID.
+          type: string
+        chunks:
+          items:
+            $ref: "#/components/schemas/ChunkHeader"
+          type: array
+        header:
+          $ref: "#/components/schemas/BlockHeader"
+      required:
+        - author
+        - chunks
+        - header
+      type: object
     BlockErrorResponse:
       additionalProperties: false
       properties:
@@ -87,6 +160,224 @@ components:
         - BLOCK_HEIGHT_TOO_LOW
         - BLOCK_DOES_NOT_EXIST
       type: string
+    BlockHeader:
+      additionalProperties: true
+      description: Block header object as served by neardata.
+      properties:
+        chunks_included:
+          format: uint64
+          type: integer
+        epoch_id:
+          type: string
+        gas_price:
+          type: string
+        hash:
+          type: string
+        height:
+          format: uint64
+          type: integer
+        next_epoch_id:
+          type: string
+        prev_hash:
+          type: string
+        prev_height:
+          format: uint64
+          type: integer
+        timestamp:
+          type: integer
+        timestamp_nanosec:
+          type: string
+        total_supply:
+          type: string
+      type: object
+    ChunkDocument:
+      additionalProperties: false
+      description: Chunk payload returned by neardata for a single shard in a selected block.
+      properties:
+        author:
+          description: Chunk producer account ID.
+          type: string
+        header:
+          $ref: "#/components/schemas/ChunkHeader"
+        receipts:
+          items:
+            $ref: "#/components/schemas/ReceiptDocument"
+          type: array
+        transactions:
+          items:
+            $ref: "#/components/schemas/ChunkTransactionWrapper"
+          type: array
+      required:
+        - author
+        - header
+        - receipts
+        - transactions
+      type: object
+    ChunkHeader:
+      additionalProperties: true
+      description: Chunk header object as served by neardata.
+      properties:
+        chunk_hash:
+          type: string
+        gas_limit:
+          type: integer
+        gas_used:
+          type: integer
+        height_created:
+          format: uint64
+          type: integer
+        height_included:
+          format: uint64
+          type: integer
+        outcome_root:
+          type: string
+        outgoing_receipts_root:
+          type: string
+        prev_block_hash:
+          type: string
+        shard_id:
+          format: uint64
+          type: integer
+        tx_root:
+          type: string
+      type: object
+    ChunkTransactionWrapper:
+      additionalProperties: false
+      description: Transaction entry returned inside a neardata chunk.
+      properties:
+        outcome:
+          $ref: "#/components/schemas/ExecutionWithReceipt"
+        transaction:
+          $ref: "#/components/schemas/SignedTransactionDocument"
+      required:
+        - outcome
+        - transaction
+      type: object
+    DataReceiptBody:
+      additionalProperties: false
+      properties:
+        Data:
+          $ref: "#/components/schemas/DataReceiptDocument"
+      required:
+        - Data
+      type: object
+    DataReceiptDocument:
+      additionalProperties: false
+      properties:
+        data:
+          type: string
+        data_id:
+          type: string
+        is_promise_resume:
+          type: boolean
+      required:
+        - data
+        - data_id
+        - is_promise_resume
+      type: object
+    ExecutionOutcomeDocument:
+      additionalProperties: false
+      properties:
+        block_hash:
+          type: string
+        id:
+          type: string
+        outcome:
+          $ref: "#/components/schemas/ExecutionOutcomeSummary"
+        proof:
+          items:
+            $ref: "#/components/schemas/ExecutionProofItem"
+          type: array
+      required:
+        - block_hash
+        - id
+        - outcome
+        - proof
+      type: object
+    ExecutionOutcomeStatus:
+      oneOf:
+        - $ref: "#/components/schemas/ExecutionOutcomeStatusSuccessReceiptId"
+        - $ref: "#/components/schemas/ExecutionOutcomeStatusSuccessValue"
+        - $ref: "#/components/schemas/ExecutionOutcomeStatusFailure"
+    ExecutionOutcomeStatusFailure:
+      additionalProperties: false
+      properties:
+        Failure:
+          additionalProperties: true
+          type: object
+      required:
+        - Failure
+      type: object
+    ExecutionOutcomeStatusSuccessReceiptId:
+      additionalProperties: false
+      properties:
+        SuccessReceiptId:
+          type: string
+      required:
+        - SuccessReceiptId
+      type: object
+    ExecutionOutcomeStatusSuccessValue:
+      additionalProperties: false
+      properties:
+        SuccessValue:
+          type: string
+      required:
+        - SuccessValue
+      type: object
+    ExecutionOutcomeSummary:
+      additionalProperties: false
+      properties:
+        executor_id:
+          type: string
+        gas_burnt:
+          format: uint64
+          type: integer
+        logs:
+          items:
+            type: string
+          type: array
+        metadata:
+          additionalProperties: true
+          type: object
+        receipt_ids:
+          items:
+            type: string
+          type: array
+        status:
+          $ref: "#/components/schemas/ExecutionOutcomeStatus"
+        tokens_burnt:
+          type: string
+      required:
+        - executor_id
+        - gas_burnt
+        - logs
+        - metadata
+        - receipt_ids
+        - status
+        - tokens_burnt
+      type: object
+    ExecutionProofItem:
+      additionalProperties: true
+      type: object
+    ExecutionWithReceipt:
+      additionalProperties: false
+      description: Execution result paired with an optional receipt object.
+      properties:
+        execution_outcome:
+          $ref: "#/components/schemas/ExecutionOutcomeDocument"
+        receipt:
+          description: Receipt payload when neardata includes it for this entry.
+          nullable: true
+          oneOf:
+            - $ref: "#/components/schemas/ReceiptDocument"
+            - $ref: "#/components/schemas/OmittedReceiptDocument"
+          type: object
+        tx_hash:
+          type: string
+      required:
+        - execution_outcome
+        - receipt
+      type: object
     HealthResponse:
       additionalProperties: false
       properties:
@@ -94,4 +385,224 @@ components:
           type: string
       required:
         - status
+      type: object
+    OmittedReceiptDocument:
+      additionalProperties: false
+      type: object
+    OutputDataReceiverDocument:
+      additionalProperties: false
+      properties:
+        data_id:
+          type: string
+        receiver_id:
+          type: string
+      required:
+        - data_id
+        - receiver_id
+      type: object
+    ReceiptBody:
+      oneOf:
+        - $ref: "#/components/schemas/ActionReceiptBody"
+        - $ref: "#/components/schemas/DataReceiptBody"
+    ReceiptDocument:
+      additionalProperties: false
+      description: Receipt object as served by neardata inside a chunk payload.
+      properties:
+        predecessor_id:
+          type: string
+        priority:
+          format: uint64
+          type: integer
+        receipt:
+          $ref: "#/components/schemas/ReceiptBody"
+        receipt_id:
+          type: string
+        receiver_id:
+          type: string
+      required:
+        - predecessor_id
+        - priority
+        - receipt
+        - receipt_id
+        - receiver_id
+      type: object
+    ShardDocument:
+      additionalProperties: false
+      description: Per-shard payload returned by neardata for a block.
+      properties:
+        chunk:
+          $ref: "#/components/schemas/ChunkDocument"
+        receipt_execution_outcomes:
+          items:
+            $ref: "#/components/schemas/ExecutionWithReceipt"
+          type: array
+        shard_id:
+          format: uint64
+          type: integer
+        state_changes:
+          items:
+            $ref: "#/components/schemas/StateChangeItem"
+          type: array
+      required:
+        - chunk
+        - receipt_execution_outcomes
+        - shard_id
+        - state_changes
+      type: object
+    SignedTransactionDocument:
+      additionalProperties: false
+      properties:
+        actions:
+          items:
+            $ref: "#/components/schemas/ActionDocument"
+          type: array
+        hash:
+          type: string
+        nonce:
+          format: uint64
+          type: integer
+        priority_fee:
+          format: uint64
+          type: integer
+        public_key:
+          type: string
+        receiver_id:
+          type: string
+        signature:
+          type: string
+        signer_id:
+          type: string
+      required:
+        - actions
+        - hash
+        - nonce
+        - priority_fee
+        - public_key
+        - receiver_id
+        - signature
+        - signer_id
+      type: object
+    StateChangeCause:
+      oneOf:
+        - $ref: "#/components/schemas/StateChangeCauseTransactionProcessing"
+        - $ref: "#/components/schemas/StateChangeCauseReceiptProcessing"
+        - $ref: "#/components/schemas/StateChangeCauseActionReceiptGasReward"
+    StateChangeCauseActionReceiptGasReward:
+      additionalProperties: false
+      properties:
+        receipt_hash:
+          type: string
+        type:
+          type: string
+      required:
+        - receipt_hash
+        - type
+      type: object
+    StateChangeCauseReceiptProcessing:
+      additionalProperties: false
+      properties:
+        receipt_hash:
+          type: string
+        type:
+          type: string
+      required:
+        - receipt_hash
+        - type
+      type: object
+    StateChangeCauseTransactionProcessing:
+      additionalProperties: false
+      properties:
+        tx_hash:
+          type: string
+        type:
+          type: string
+      required:
+        - tx_hash
+        - type
+      type: object
+    StateChangeItem:
+      additionalProperties: false
+      description: State change entry returned by neardata for a shard.
+      properties:
+        cause:
+          $ref: "#/components/schemas/StateChangeCause"
+        change:
+          $ref: "#/components/schemas/StateChangeValue"
+        type:
+          type: string
+      required:
+        - cause
+        - change
+        - type
+      type: object
+    StateChangeValue:
+      oneOf:
+        - $ref: "#/components/schemas/StateChangeValueAccountUpdate"
+        - $ref: "#/components/schemas/StateChangeValueAccessKeyUpdate"
+        - $ref: "#/components/schemas/StateChangeValueDataUpdate"
+        - $ref: "#/components/schemas/StateChangeValueDataDeletion"
+    StateChangeValueAccessKeyUpdate:
+      additionalProperties: false
+      properties:
+        access_key:
+          additionalProperties: true
+          type: object
+        account_id:
+          type: string
+        public_key:
+          type: string
+      required:
+        - access_key
+        - account_id
+        - public_key
+      type: object
+    StateChangeValueAccountUpdate:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        amount:
+          type: string
+        code_hash:
+          type: string
+        locked:
+          type: string
+        storage_paid_at:
+          format: uint64
+          type: integer
+        storage_usage:
+          format: uint64
+          type: integer
+      required:
+        - account_id
+        - amount
+        - code_hash
+        - locked
+        - storage_paid_at
+        - storage_usage
+      type: object
+    StateChangeValueDataDeletion:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        key_base64:
+          type: string
+      required:
+        - account_id
+        - key_base64
+      type: object
+    StateChangeValueDataUpdate:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        key_base64:
+          type: string
+        value_base64:
+          type: string
+      required:
+        - account_id
+        - key_base64
+        - value_base64
       type: object

--- a/apis/neardata/v0/block_optimistic.yaml
+++ b/apis/neardata/v0/block_optimistic.yaml
@@ -27,10 +27,8 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
-                description: Full block document as served by neardata, including `block` and `shards`.
+                $ref: "#/components/schemas/BlockDocument"
                 nullable: true
-                type: object
           description: Requested document, or `null` when the selected slice is absent
         "302":
           description: Redirect to a canonical archive or finalized block URL
@@ -70,6 +68,81 @@ servers:
     url: https://testnet.neardata.xyz
 components:
   schemas:
+    ActionDocument:
+      additionalProperties: true
+      type: object
+    ActionReceiptBody:
+      additionalProperties: false
+      properties:
+        Action:
+          $ref: "#/components/schemas/ActionReceiptDocument"
+      required:
+        - Action
+      type: object
+    ActionReceiptDocument:
+      additionalProperties: false
+      properties:
+        actions:
+          items:
+            $ref: "#/components/schemas/ActionDocument"
+          type: array
+        gas_price:
+          type: string
+        input_data_ids:
+          items:
+            type: string
+          type: array
+        is_promise_yield:
+          type: boolean
+        output_data_receivers:
+          items:
+            $ref: "#/components/schemas/OutputDataReceiverDocument"
+          type: array
+        signer_id:
+          type: string
+        signer_public_key:
+          type: string
+      required:
+        - actions
+        - gas_price
+        - input_data_ids
+        - is_promise_yield
+        - output_data_receivers
+        - signer_id
+        - signer_public_key
+      type: object
+    BlockDocument:
+      additionalProperties: false
+      description: Full block document as served by neardata, including the block envelope and per-shard payloads.
+      properties:
+        block:
+          $ref: "#/components/schemas/BlockEnvelope"
+        shards:
+          items:
+            $ref: "#/components/schemas/ShardDocument"
+          type: array
+      required:
+        - block
+        - shards
+      type: object
+    BlockEnvelope:
+      additionalProperties: false
+      description: Block-level payload returned by neardata.
+      properties:
+        author:
+          description: Block producer account ID.
+          type: string
+        chunks:
+          items:
+            $ref: "#/components/schemas/ChunkHeader"
+          type: array
+        header:
+          $ref: "#/components/schemas/BlockHeader"
+      required:
+        - author
+        - chunks
+        - header
+      type: object
     BlockErrorResponse:
       additionalProperties: false
       properties:
@@ -87,6 +160,224 @@ components:
         - BLOCK_HEIGHT_TOO_LOW
         - BLOCK_DOES_NOT_EXIST
       type: string
+    BlockHeader:
+      additionalProperties: true
+      description: Block header object as served by neardata.
+      properties:
+        chunks_included:
+          format: uint64
+          type: integer
+        epoch_id:
+          type: string
+        gas_price:
+          type: string
+        hash:
+          type: string
+        height:
+          format: uint64
+          type: integer
+        next_epoch_id:
+          type: string
+        prev_hash:
+          type: string
+        prev_height:
+          format: uint64
+          type: integer
+        timestamp:
+          type: integer
+        timestamp_nanosec:
+          type: string
+        total_supply:
+          type: string
+      type: object
+    ChunkDocument:
+      additionalProperties: false
+      description: Chunk payload returned by neardata for a single shard in a selected block.
+      properties:
+        author:
+          description: Chunk producer account ID.
+          type: string
+        header:
+          $ref: "#/components/schemas/ChunkHeader"
+        receipts:
+          items:
+            $ref: "#/components/schemas/ReceiptDocument"
+          type: array
+        transactions:
+          items:
+            $ref: "#/components/schemas/ChunkTransactionWrapper"
+          type: array
+      required:
+        - author
+        - header
+        - receipts
+        - transactions
+      type: object
+    ChunkHeader:
+      additionalProperties: true
+      description: Chunk header object as served by neardata.
+      properties:
+        chunk_hash:
+          type: string
+        gas_limit:
+          type: integer
+        gas_used:
+          type: integer
+        height_created:
+          format: uint64
+          type: integer
+        height_included:
+          format: uint64
+          type: integer
+        outcome_root:
+          type: string
+        outgoing_receipts_root:
+          type: string
+        prev_block_hash:
+          type: string
+        shard_id:
+          format: uint64
+          type: integer
+        tx_root:
+          type: string
+      type: object
+    ChunkTransactionWrapper:
+      additionalProperties: false
+      description: Transaction entry returned inside a neardata chunk.
+      properties:
+        outcome:
+          $ref: "#/components/schemas/ExecutionWithReceipt"
+        transaction:
+          $ref: "#/components/schemas/SignedTransactionDocument"
+      required:
+        - outcome
+        - transaction
+      type: object
+    DataReceiptBody:
+      additionalProperties: false
+      properties:
+        Data:
+          $ref: "#/components/schemas/DataReceiptDocument"
+      required:
+        - Data
+      type: object
+    DataReceiptDocument:
+      additionalProperties: false
+      properties:
+        data:
+          type: string
+        data_id:
+          type: string
+        is_promise_resume:
+          type: boolean
+      required:
+        - data
+        - data_id
+        - is_promise_resume
+      type: object
+    ExecutionOutcomeDocument:
+      additionalProperties: false
+      properties:
+        block_hash:
+          type: string
+        id:
+          type: string
+        outcome:
+          $ref: "#/components/schemas/ExecutionOutcomeSummary"
+        proof:
+          items:
+            $ref: "#/components/schemas/ExecutionProofItem"
+          type: array
+      required:
+        - block_hash
+        - id
+        - outcome
+        - proof
+      type: object
+    ExecutionOutcomeStatus:
+      oneOf:
+        - $ref: "#/components/schemas/ExecutionOutcomeStatusSuccessReceiptId"
+        - $ref: "#/components/schemas/ExecutionOutcomeStatusSuccessValue"
+        - $ref: "#/components/schemas/ExecutionOutcomeStatusFailure"
+    ExecutionOutcomeStatusFailure:
+      additionalProperties: false
+      properties:
+        Failure:
+          additionalProperties: true
+          type: object
+      required:
+        - Failure
+      type: object
+    ExecutionOutcomeStatusSuccessReceiptId:
+      additionalProperties: false
+      properties:
+        SuccessReceiptId:
+          type: string
+      required:
+        - SuccessReceiptId
+      type: object
+    ExecutionOutcomeStatusSuccessValue:
+      additionalProperties: false
+      properties:
+        SuccessValue:
+          type: string
+      required:
+        - SuccessValue
+      type: object
+    ExecutionOutcomeSummary:
+      additionalProperties: false
+      properties:
+        executor_id:
+          type: string
+        gas_burnt:
+          format: uint64
+          type: integer
+        logs:
+          items:
+            type: string
+          type: array
+        metadata:
+          additionalProperties: true
+          type: object
+        receipt_ids:
+          items:
+            type: string
+          type: array
+        status:
+          $ref: "#/components/schemas/ExecutionOutcomeStatus"
+        tokens_burnt:
+          type: string
+      required:
+        - executor_id
+        - gas_burnt
+        - logs
+        - metadata
+        - receipt_ids
+        - status
+        - tokens_burnt
+      type: object
+    ExecutionProofItem:
+      additionalProperties: true
+      type: object
+    ExecutionWithReceipt:
+      additionalProperties: false
+      description: Execution result paired with an optional receipt object.
+      properties:
+        execution_outcome:
+          $ref: "#/components/schemas/ExecutionOutcomeDocument"
+        receipt:
+          description: Receipt payload when neardata includes it for this entry.
+          nullable: true
+          oneOf:
+            - $ref: "#/components/schemas/ReceiptDocument"
+            - $ref: "#/components/schemas/OmittedReceiptDocument"
+          type: object
+        tx_hash:
+          type: string
+      required:
+        - execution_outcome
+        - receipt
+      type: object
     HealthResponse:
       additionalProperties: false
       properties:
@@ -94,4 +385,224 @@ components:
           type: string
       required:
         - status
+      type: object
+    OmittedReceiptDocument:
+      additionalProperties: false
+      type: object
+    OutputDataReceiverDocument:
+      additionalProperties: false
+      properties:
+        data_id:
+          type: string
+        receiver_id:
+          type: string
+      required:
+        - data_id
+        - receiver_id
+      type: object
+    ReceiptBody:
+      oneOf:
+        - $ref: "#/components/schemas/ActionReceiptBody"
+        - $ref: "#/components/schemas/DataReceiptBody"
+    ReceiptDocument:
+      additionalProperties: false
+      description: Receipt object as served by neardata inside a chunk payload.
+      properties:
+        predecessor_id:
+          type: string
+        priority:
+          format: uint64
+          type: integer
+        receipt:
+          $ref: "#/components/schemas/ReceiptBody"
+        receipt_id:
+          type: string
+        receiver_id:
+          type: string
+      required:
+        - predecessor_id
+        - priority
+        - receipt
+        - receipt_id
+        - receiver_id
+      type: object
+    ShardDocument:
+      additionalProperties: false
+      description: Per-shard payload returned by neardata for a block.
+      properties:
+        chunk:
+          $ref: "#/components/schemas/ChunkDocument"
+        receipt_execution_outcomes:
+          items:
+            $ref: "#/components/schemas/ExecutionWithReceipt"
+          type: array
+        shard_id:
+          format: uint64
+          type: integer
+        state_changes:
+          items:
+            $ref: "#/components/schemas/StateChangeItem"
+          type: array
+      required:
+        - chunk
+        - receipt_execution_outcomes
+        - shard_id
+        - state_changes
+      type: object
+    SignedTransactionDocument:
+      additionalProperties: false
+      properties:
+        actions:
+          items:
+            $ref: "#/components/schemas/ActionDocument"
+          type: array
+        hash:
+          type: string
+        nonce:
+          format: uint64
+          type: integer
+        priority_fee:
+          format: uint64
+          type: integer
+        public_key:
+          type: string
+        receiver_id:
+          type: string
+        signature:
+          type: string
+        signer_id:
+          type: string
+      required:
+        - actions
+        - hash
+        - nonce
+        - priority_fee
+        - public_key
+        - receiver_id
+        - signature
+        - signer_id
+      type: object
+    StateChangeCause:
+      oneOf:
+        - $ref: "#/components/schemas/StateChangeCauseTransactionProcessing"
+        - $ref: "#/components/schemas/StateChangeCauseReceiptProcessing"
+        - $ref: "#/components/schemas/StateChangeCauseActionReceiptGasReward"
+    StateChangeCauseActionReceiptGasReward:
+      additionalProperties: false
+      properties:
+        receipt_hash:
+          type: string
+        type:
+          type: string
+      required:
+        - receipt_hash
+        - type
+      type: object
+    StateChangeCauseReceiptProcessing:
+      additionalProperties: false
+      properties:
+        receipt_hash:
+          type: string
+        type:
+          type: string
+      required:
+        - receipt_hash
+        - type
+      type: object
+    StateChangeCauseTransactionProcessing:
+      additionalProperties: false
+      properties:
+        tx_hash:
+          type: string
+        type:
+          type: string
+      required:
+        - tx_hash
+        - type
+      type: object
+    StateChangeItem:
+      additionalProperties: false
+      description: State change entry returned by neardata for a shard.
+      properties:
+        cause:
+          $ref: "#/components/schemas/StateChangeCause"
+        change:
+          $ref: "#/components/schemas/StateChangeValue"
+        type:
+          type: string
+      required:
+        - cause
+        - change
+        - type
+      type: object
+    StateChangeValue:
+      oneOf:
+        - $ref: "#/components/schemas/StateChangeValueAccountUpdate"
+        - $ref: "#/components/schemas/StateChangeValueAccessKeyUpdate"
+        - $ref: "#/components/schemas/StateChangeValueDataUpdate"
+        - $ref: "#/components/schemas/StateChangeValueDataDeletion"
+    StateChangeValueAccessKeyUpdate:
+      additionalProperties: false
+      properties:
+        access_key:
+          additionalProperties: true
+          type: object
+        account_id:
+          type: string
+        public_key:
+          type: string
+      required:
+        - access_key
+        - account_id
+        - public_key
+      type: object
+    StateChangeValueAccountUpdate:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        amount:
+          type: string
+        code_hash:
+          type: string
+        locked:
+          type: string
+        storage_paid_at:
+          format: uint64
+          type: integer
+        storage_usage:
+          format: uint64
+          type: integer
+      required:
+        - account_id
+        - amount
+        - code_hash
+        - locked
+        - storage_paid_at
+        - storage_usage
+      type: object
+    StateChangeValueDataDeletion:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        key_base64:
+          type: string
+      required:
+        - account_id
+        - key_base64
+      type: object
+    StateChangeValueDataUpdate:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        key_base64:
+          type: string
+        value_base64:
+          type: string
+      required:
+        - account_id
+        - key_base64
+        - value_base64
       type: object

--- a/apis/neardata/v0/block_shard.yaml
+++ b/apis/neardata/v0/block_shard.yaml
@@ -34,10 +34,8 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
-                description: Shard object for the requested shard ID.
+                $ref: "#/components/schemas/ShardDocument"
                 nullable: true
-                type: object
           description: Requested document, or `null` when the selected slice is absent
         "302":
           description: Redirect to a canonical archive or finalized block URL
@@ -77,6 +75,81 @@ servers:
     url: https://testnet.neardata.xyz
 components:
   schemas:
+    ActionDocument:
+      additionalProperties: true
+      type: object
+    ActionReceiptBody:
+      additionalProperties: false
+      properties:
+        Action:
+          $ref: "#/components/schemas/ActionReceiptDocument"
+      required:
+        - Action
+      type: object
+    ActionReceiptDocument:
+      additionalProperties: false
+      properties:
+        actions:
+          items:
+            $ref: "#/components/schemas/ActionDocument"
+          type: array
+        gas_price:
+          type: string
+        input_data_ids:
+          items:
+            type: string
+          type: array
+        is_promise_yield:
+          type: boolean
+        output_data_receivers:
+          items:
+            $ref: "#/components/schemas/OutputDataReceiverDocument"
+          type: array
+        signer_id:
+          type: string
+        signer_public_key:
+          type: string
+      required:
+        - actions
+        - gas_price
+        - input_data_ids
+        - is_promise_yield
+        - output_data_receivers
+        - signer_id
+        - signer_public_key
+      type: object
+    BlockDocument:
+      additionalProperties: false
+      description: Full block document as served by neardata, including the block envelope and per-shard payloads.
+      properties:
+        block:
+          $ref: "#/components/schemas/BlockEnvelope"
+        shards:
+          items:
+            $ref: "#/components/schemas/ShardDocument"
+          type: array
+      required:
+        - block
+        - shards
+      type: object
+    BlockEnvelope:
+      additionalProperties: false
+      description: Block-level payload returned by neardata.
+      properties:
+        author:
+          description: Block producer account ID.
+          type: string
+        chunks:
+          items:
+            $ref: "#/components/schemas/ChunkHeader"
+          type: array
+        header:
+          $ref: "#/components/schemas/BlockHeader"
+      required:
+        - author
+        - chunks
+        - header
+      type: object
     BlockErrorResponse:
       additionalProperties: false
       properties:
@@ -94,6 +167,224 @@ components:
         - BLOCK_HEIGHT_TOO_LOW
         - BLOCK_DOES_NOT_EXIST
       type: string
+    BlockHeader:
+      additionalProperties: true
+      description: Block header object as served by neardata.
+      properties:
+        chunks_included:
+          format: uint64
+          type: integer
+        epoch_id:
+          type: string
+        gas_price:
+          type: string
+        hash:
+          type: string
+        height:
+          format: uint64
+          type: integer
+        next_epoch_id:
+          type: string
+        prev_hash:
+          type: string
+        prev_height:
+          format: uint64
+          type: integer
+        timestamp:
+          type: integer
+        timestamp_nanosec:
+          type: string
+        total_supply:
+          type: string
+      type: object
+    ChunkDocument:
+      additionalProperties: false
+      description: Chunk payload returned by neardata for a single shard in a selected block.
+      properties:
+        author:
+          description: Chunk producer account ID.
+          type: string
+        header:
+          $ref: "#/components/schemas/ChunkHeader"
+        receipts:
+          items:
+            $ref: "#/components/schemas/ReceiptDocument"
+          type: array
+        transactions:
+          items:
+            $ref: "#/components/schemas/ChunkTransactionWrapper"
+          type: array
+      required:
+        - author
+        - header
+        - receipts
+        - transactions
+      type: object
+    ChunkHeader:
+      additionalProperties: true
+      description: Chunk header object as served by neardata.
+      properties:
+        chunk_hash:
+          type: string
+        gas_limit:
+          type: integer
+        gas_used:
+          type: integer
+        height_created:
+          format: uint64
+          type: integer
+        height_included:
+          format: uint64
+          type: integer
+        outcome_root:
+          type: string
+        outgoing_receipts_root:
+          type: string
+        prev_block_hash:
+          type: string
+        shard_id:
+          format: uint64
+          type: integer
+        tx_root:
+          type: string
+      type: object
+    ChunkTransactionWrapper:
+      additionalProperties: false
+      description: Transaction entry returned inside a neardata chunk.
+      properties:
+        outcome:
+          $ref: "#/components/schemas/ExecutionWithReceipt"
+        transaction:
+          $ref: "#/components/schemas/SignedTransactionDocument"
+      required:
+        - outcome
+        - transaction
+      type: object
+    DataReceiptBody:
+      additionalProperties: false
+      properties:
+        Data:
+          $ref: "#/components/schemas/DataReceiptDocument"
+      required:
+        - Data
+      type: object
+    DataReceiptDocument:
+      additionalProperties: false
+      properties:
+        data:
+          type: string
+        data_id:
+          type: string
+        is_promise_resume:
+          type: boolean
+      required:
+        - data
+        - data_id
+        - is_promise_resume
+      type: object
+    ExecutionOutcomeDocument:
+      additionalProperties: false
+      properties:
+        block_hash:
+          type: string
+        id:
+          type: string
+        outcome:
+          $ref: "#/components/schemas/ExecutionOutcomeSummary"
+        proof:
+          items:
+            $ref: "#/components/schemas/ExecutionProofItem"
+          type: array
+      required:
+        - block_hash
+        - id
+        - outcome
+        - proof
+      type: object
+    ExecutionOutcomeStatus:
+      oneOf:
+        - $ref: "#/components/schemas/ExecutionOutcomeStatusSuccessReceiptId"
+        - $ref: "#/components/schemas/ExecutionOutcomeStatusSuccessValue"
+        - $ref: "#/components/schemas/ExecutionOutcomeStatusFailure"
+    ExecutionOutcomeStatusFailure:
+      additionalProperties: false
+      properties:
+        Failure:
+          additionalProperties: true
+          type: object
+      required:
+        - Failure
+      type: object
+    ExecutionOutcomeStatusSuccessReceiptId:
+      additionalProperties: false
+      properties:
+        SuccessReceiptId:
+          type: string
+      required:
+        - SuccessReceiptId
+      type: object
+    ExecutionOutcomeStatusSuccessValue:
+      additionalProperties: false
+      properties:
+        SuccessValue:
+          type: string
+      required:
+        - SuccessValue
+      type: object
+    ExecutionOutcomeSummary:
+      additionalProperties: false
+      properties:
+        executor_id:
+          type: string
+        gas_burnt:
+          format: uint64
+          type: integer
+        logs:
+          items:
+            type: string
+          type: array
+        metadata:
+          additionalProperties: true
+          type: object
+        receipt_ids:
+          items:
+            type: string
+          type: array
+        status:
+          $ref: "#/components/schemas/ExecutionOutcomeStatus"
+        tokens_burnt:
+          type: string
+      required:
+        - executor_id
+        - gas_burnt
+        - logs
+        - metadata
+        - receipt_ids
+        - status
+        - tokens_burnt
+      type: object
+    ExecutionProofItem:
+      additionalProperties: true
+      type: object
+    ExecutionWithReceipt:
+      additionalProperties: false
+      description: Execution result paired with an optional receipt object.
+      properties:
+        execution_outcome:
+          $ref: "#/components/schemas/ExecutionOutcomeDocument"
+        receipt:
+          description: Receipt payload when neardata includes it for this entry.
+          nullable: true
+          oneOf:
+            - $ref: "#/components/schemas/ReceiptDocument"
+            - $ref: "#/components/schemas/OmittedReceiptDocument"
+          type: object
+        tx_hash:
+          type: string
+      required:
+        - execution_outcome
+        - receipt
+      type: object
     HealthResponse:
       additionalProperties: false
       properties:
@@ -101,4 +392,224 @@ components:
           type: string
       required:
         - status
+      type: object
+    OmittedReceiptDocument:
+      additionalProperties: false
+      type: object
+    OutputDataReceiverDocument:
+      additionalProperties: false
+      properties:
+        data_id:
+          type: string
+        receiver_id:
+          type: string
+      required:
+        - data_id
+        - receiver_id
+      type: object
+    ReceiptBody:
+      oneOf:
+        - $ref: "#/components/schemas/ActionReceiptBody"
+        - $ref: "#/components/schemas/DataReceiptBody"
+    ReceiptDocument:
+      additionalProperties: false
+      description: Receipt object as served by neardata inside a chunk payload.
+      properties:
+        predecessor_id:
+          type: string
+        priority:
+          format: uint64
+          type: integer
+        receipt:
+          $ref: "#/components/schemas/ReceiptBody"
+        receipt_id:
+          type: string
+        receiver_id:
+          type: string
+      required:
+        - predecessor_id
+        - priority
+        - receipt
+        - receipt_id
+        - receiver_id
+      type: object
+    ShardDocument:
+      additionalProperties: false
+      description: Per-shard payload returned by neardata for a block.
+      properties:
+        chunk:
+          $ref: "#/components/schemas/ChunkDocument"
+        receipt_execution_outcomes:
+          items:
+            $ref: "#/components/schemas/ExecutionWithReceipt"
+          type: array
+        shard_id:
+          format: uint64
+          type: integer
+        state_changes:
+          items:
+            $ref: "#/components/schemas/StateChangeItem"
+          type: array
+      required:
+        - chunk
+        - receipt_execution_outcomes
+        - shard_id
+        - state_changes
+      type: object
+    SignedTransactionDocument:
+      additionalProperties: false
+      properties:
+        actions:
+          items:
+            $ref: "#/components/schemas/ActionDocument"
+          type: array
+        hash:
+          type: string
+        nonce:
+          format: uint64
+          type: integer
+        priority_fee:
+          format: uint64
+          type: integer
+        public_key:
+          type: string
+        receiver_id:
+          type: string
+        signature:
+          type: string
+        signer_id:
+          type: string
+      required:
+        - actions
+        - hash
+        - nonce
+        - priority_fee
+        - public_key
+        - receiver_id
+        - signature
+        - signer_id
+      type: object
+    StateChangeCause:
+      oneOf:
+        - $ref: "#/components/schemas/StateChangeCauseTransactionProcessing"
+        - $ref: "#/components/schemas/StateChangeCauseReceiptProcessing"
+        - $ref: "#/components/schemas/StateChangeCauseActionReceiptGasReward"
+    StateChangeCauseActionReceiptGasReward:
+      additionalProperties: false
+      properties:
+        receipt_hash:
+          type: string
+        type:
+          type: string
+      required:
+        - receipt_hash
+        - type
+      type: object
+    StateChangeCauseReceiptProcessing:
+      additionalProperties: false
+      properties:
+        receipt_hash:
+          type: string
+        type:
+          type: string
+      required:
+        - receipt_hash
+        - type
+      type: object
+    StateChangeCauseTransactionProcessing:
+      additionalProperties: false
+      properties:
+        tx_hash:
+          type: string
+        type:
+          type: string
+      required:
+        - tx_hash
+        - type
+      type: object
+    StateChangeItem:
+      additionalProperties: false
+      description: State change entry returned by neardata for a shard.
+      properties:
+        cause:
+          $ref: "#/components/schemas/StateChangeCause"
+        change:
+          $ref: "#/components/schemas/StateChangeValue"
+        type:
+          type: string
+      required:
+        - cause
+        - change
+        - type
+      type: object
+    StateChangeValue:
+      oneOf:
+        - $ref: "#/components/schemas/StateChangeValueAccountUpdate"
+        - $ref: "#/components/schemas/StateChangeValueAccessKeyUpdate"
+        - $ref: "#/components/schemas/StateChangeValueDataUpdate"
+        - $ref: "#/components/schemas/StateChangeValueDataDeletion"
+    StateChangeValueAccessKeyUpdate:
+      additionalProperties: false
+      properties:
+        access_key:
+          additionalProperties: true
+          type: object
+        account_id:
+          type: string
+        public_key:
+          type: string
+      required:
+        - access_key
+        - account_id
+        - public_key
+      type: object
+    StateChangeValueAccountUpdate:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        amount:
+          type: string
+        code_hash:
+          type: string
+        locked:
+          type: string
+        storage_paid_at:
+          format: uint64
+          type: integer
+        storage_usage:
+          format: uint64
+          type: integer
+      required:
+        - account_id
+        - amount
+        - code_hash
+        - locked
+        - storage_paid_at
+        - storage_usage
+      type: object
+    StateChangeValueDataDeletion:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        key_base64:
+          type: string
+      required:
+        - account_id
+        - key_base64
+      type: object
+    StateChangeValueDataUpdate:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        key_base64:
+          type: string
+        value_base64:
+          type: string
+      required:
+        - account_id
+        - key_base64
+        - value_base64
       type: object

--- a/apis/neardata/v0/first_block.yaml
+++ b/apis/neardata/v0/first_block.yaml
@@ -20,10 +20,8 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
-                description: Full block document as served by neardata, including `block` and `shards`.
+                $ref: "#/components/schemas/BlockDocument"
                 nullable: true
-                type: object
           description: Full block document returned after automatic redirect following
         "302":
           description: Redirect to the canonical first block URL
@@ -48,6 +46,81 @@ servers:
     url: https://testnet.neardata.xyz
 components:
   schemas:
+    ActionDocument:
+      additionalProperties: true
+      type: object
+    ActionReceiptBody:
+      additionalProperties: false
+      properties:
+        Action:
+          $ref: "#/components/schemas/ActionReceiptDocument"
+      required:
+        - Action
+      type: object
+    ActionReceiptDocument:
+      additionalProperties: false
+      properties:
+        actions:
+          items:
+            $ref: "#/components/schemas/ActionDocument"
+          type: array
+        gas_price:
+          type: string
+        input_data_ids:
+          items:
+            type: string
+          type: array
+        is_promise_yield:
+          type: boolean
+        output_data_receivers:
+          items:
+            $ref: "#/components/schemas/OutputDataReceiverDocument"
+          type: array
+        signer_id:
+          type: string
+        signer_public_key:
+          type: string
+      required:
+        - actions
+        - gas_price
+        - input_data_ids
+        - is_promise_yield
+        - output_data_receivers
+        - signer_id
+        - signer_public_key
+      type: object
+    BlockDocument:
+      additionalProperties: false
+      description: Full block document as served by neardata, including the block envelope and per-shard payloads.
+      properties:
+        block:
+          $ref: "#/components/schemas/BlockEnvelope"
+        shards:
+          items:
+            $ref: "#/components/schemas/ShardDocument"
+          type: array
+      required:
+        - block
+        - shards
+      type: object
+    BlockEnvelope:
+      additionalProperties: false
+      description: Block-level payload returned by neardata.
+      properties:
+        author:
+          description: Block producer account ID.
+          type: string
+        chunks:
+          items:
+            $ref: "#/components/schemas/ChunkHeader"
+          type: array
+        header:
+          $ref: "#/components/schemas/BlockHeader"
+      required:
+        - author
+        - chunks
+        - header
+      type: object
     BlockErrorResponse:
       additionalProperties: false
       properties:
@@ -65,6 +138,224 @@ components:
         - BLOCK_HEIGHT_TOO_LOW
         - BLOCK_DOES_NOT_EXIST
       type: string
+    BlockHeader:
+      additionalProperties: true
+      description: Block header object as served by neardata.
+      properties:
+        chunks_included:
+          format: uint64
+          type: integer
+        epoch_id:
+          type: string
+        gas_price:
+          type: string
+        hash:
+          type: string
+        height:
+          format: uint64
+          type: integer
+        next_epoch_id:
+          type: string
+        prev_hash:
+          type: string
+        prev_height:
+          format: uint64
+          type: integer
+        timestamp:
+          type: integer
+        timestamp_nanosec:
+          type: string
+        total_supply:
+          type: string
+      type: object
+    ChunkDocument:
+      additionalProperties: false
+      description: Chunk payload returned by neardata for a single shard in a selected block.
+      properties:
+        author:
+          description: Chunk producer account ID.
+          type: string
+        header:
+          $ref: "#/components/schemas/ChunkHeader"
+        receipts:
+          items:
+            $ref: "#/components/schemas/ReceiptDocument"
+          type: array
+        transactions:
+          items:
+            $ref: "#/components/schemas/ChunkTransactionWrapper"
+          type: array
+      required:
+        - author
+        - header
+        - receipts
+        - transactions
+      type: object
+    ChunkHeader:
+      additionalProperties: true
+      description: Chunk header object as served by neardata.
+      properties:
+        chunk_hash:
+          type: string
+        gas_limit:
+          type: integer
+        gas_used:
+          type: integer
+        height_created:
+          format: uint64
+          type: integer
+        height_included:
+          format: uint64
+          type: integer
+        outcome_root:
+          type: string
+        outgoing_receipts_root:
+          type: string
+        prev_block_hash:
+          type: string
+        shard_id:
+          format: uint64
+          type: integer
+        tx_root:
+          type: string
+      type: object
+    ChunkTransactionWrapper:
+      additionalProperties: false
+      description: Transaction entry returned inside a neardata chunk.
+      properties:
+        outcome:
+          $ref: "#/components/schemas/ExecutionWithReceipt"
+        transaction:
+          $ref: "#/components/schemas/SignedTransactionDocument"
+      required:
+        - outcome
+        - transaction
+      type: object
+    DataReceiptBody:
+      additionalProperties: false
+      properties:
+        Data:
+          $ref: "#/components/schemas/DataReceiptDocument"
+      required:
+        - Data
+      type: object
+    DataReceiptDocument:
+      additionalProperties: false
+      properties:
+        data:
+          type: string
+        data_id:
+          type: string
+        is_promise_resume:
+          type: boolean
+      required:
+        - data
+        - data_id
+        - is_promise_resume
+      type: object
+    ExecutionOutcomeDocument:
+      additionalProperties: false
+      properties:
+        block_hash:
+          type: string
+        id:
+          type: string
+        outcome:
+          $ref: "#/components/schemas/ExecutionOutcomeSummary"
+        proof:
+          items:
+            $ref: "#/components/schemas/ExecutionProofItem"
+          type: array
+      required:
+        - block_hash
+        - id
+        - outcome
+        - proof
+      type: object
+    ExecutionOutcomeStatus:
+      oneOf:
+        - $ref: "#/components/schemas/ExecutionOutcomeStatusSuccessReceiptId"
+        - $ref: "#/components/schemas/ExecutionOutcomeStatusSuccessValue"
+        - $ref: "#/components/schemas/ExecutionOutcomeStatusFailure"
+    ExecutionOutcomeStatusFailure:
+      additionalProperties: false
+      properties:
+        Failure:
+          additionalProperties: true
+          type: object
+      required:
+        - Failure
+      type: object
+    ExecutionOutcomeStatusSuccessReceiptId:
+      additionalProperties: false
+      properties:
+        SuccessReceiptId:
+          type: string
+      required:
+        - SuccessReceiptId
+      type: object
+    ExecutionOutcomeStatusSuccessValue:
+      additionalProperties: false
+      properties:
+        SuccessValue:
+          type: string
+      required:
+        - SuccessValue
+      type: object
+    ExecutionOutcomeSummary:
+      additionalProperties: false
+      properties:
+        executor_id:
+          type: string
+        gas_burnt:
+          format: uint64
+          type: integer
+        logs:
+          items:
+            type: string
+          type: array
+        metadata:
+          additionalProperties: true
+          type: object
+        receipt_ids:
+          items:
+            type: string
+          type: array
+        status:
+          $ref: "#/components/schemas/ExecutionOutcomeStatus"
+        tokens_burnt:
+          type: string
+      required:
+        - executor_id
+        - gas_burnt
+        - logs
+        - metadata
+        - receipt_ids
+        - status
+        - tokens_burnt
+      type: object
+    ExecutionProofItem:
+      additionalProperties: true
+      type: object
+    ExecutionWithReceipt:
+      additionalProperties: false
+      description: Execution result paired with an optional receipt object.
+      properties:
+        execution_outcome:
+          $ref: "#/components/schemas/ExecutionOutcomeDocument"
+        receipt:
+          description: Receipt payload when neardata includes it for this entry.
+          nullable: true
+          oneOf:
+            - $ref: "#/components/schemas/ReceiptDocument"
+            - $ref: "#/components/schemas/OmittedReceiptDocument"
+          type: object
+        tx_hash:
+          type: string
+      required:
+        - execution_outcome
+        - receipt
+      type: object
     HealthResponse:
       additionalProperties: false
       properties:
@@ -72,4 +363,224 @@ components:
           type: string
       required:
         - status
+      type: object
+    OmittedReceiptDocument:
+      additionalProperties: false
+      type: object
+    OutputDataReceiverDocument:
+      additionalProperties: false
+      properties:
+        data_id:
+          type: string
+        receiver_id:
+          type: string
+      required:
+        - data_id
+        - receiver_id
+      type: object
+    ReceiptBody:
+      oneOf:
+        - $ref: "#/components/schemas/ActionReceiptBody"
+        - $ref: "#/components/schemas/DataReceiptBody"
+    ReceiptDocument:
+      additionalProperties: false
+      description: Receipt object as served by neardata inside a chunk payload.
+      properties:
+        predecessor_id:
+          type: string
+        priority:
+          format: uint64
+          type: integer
+        receipt:
+          $ref: "#/components/schemas/ReceiptBody"
+        receipt_id:
+          type: string
+        receiver_id:
+          type: string
+      required:
+        - predecessor_id
+        - priority
+        - receipt
+        - receipt_id
+        - receiver_id
+      type: object
+    ShardDocument:
+      additionalProperties: false
+      description: Per-shard payload returned by neardata for a block.
+      properties:
+        chunk:
+          $ref: "#/components/schemas/ChunkDocument"
+        receipt_execution_outcomes:
+          items:
+            $ref: "#/components/schemas/ExecutionWithReceipt"
+          type: array
+        shard_id:
+          format: uint64
+          type: integer
+        state_changes:
+          items:
+            $ref: "#/components/schemas/StateChangeItem"
+          type: array
+      required:
+        - chunk
+        - receipt_execution_outcomes
+        - shard_id
+        - state_changes
+      type: object
+    SignedTransactionDocument:
+      additionalProperties: false
+      properties:
+        actions:
+          items:
+            $ref: "#/components/schemas/ActionDocument"
+          type: array
+        hash:
+          type: string
+        nonce:
+          format: uint64
+          type: integer
+        priority_fee:
+          format: uint64
+          type: integer
+        public_key:
+          type: string
+        receiver_id:
+          type: string
+        signature:
+          type: string
+        signer_id:
+          type: string
+      required:
+        - actions
+        - hash
+        - nonce
+        - priority_fee
+        - public_key
+        - receiver_id
+        - signature
+        - signer_id
+      type: object
+    StateChangeCause:
+      oneOf:
+        - $ref: "#/components/schemas/StateChangeCauseTransactionProcessing"
+        - $ref: "#/components/schemas/StateChangeCauseReceiptProcessing"
+        - $ref: "#/components/schemas/StateChangeCauseActionReceiptGasReward"
+    StateChangeCauseActionReceiptGasReward:
+      additionalProperties: false
+      properties:
+        receipt_hash:
+          type: string
+        type:
+          type: string
+      required:
+        - receipt_hash
+        - type
+      type: object
+    StateChangeCauseReceiptProcessing:
+      additionalProperties: false
+      properties:
+        receipt_hash:
+          type: string
+        type:
+          type: string
+      required:
+        - receipt_hash
+        - type
+      type: object
+    StateChangeCauseTransactionProcessing:
+      additionalProperties: false
+      properties:
+        tx_hash:
+          type: string
+        type:
+          type: string
+      required:
+        - tx_hash
+        - type
+      type: object
+    StateChangeItem:
+      additionalProperties: false
+      description: State change entry returned by neardata for a shard.
+      properties:
+        cause:
+          $ref: "#/components/schemas/StateChangeCause"
+        change:
+          $ref: "#/components/schemas/StateChangeValue"
+        type:
+          type: string
+      required:
+        - cause
+        - change
+        - type
+      type: object
+    StateChangeValue:
+      oneOf:
+        - $ref: "#/components/schemas/StateChangeValueAccountUpdate"
+        - $ref: "#/components/schemas/StateChangeValueAccessKeyUpdate"
+        - $ref: "#/components/schemas/StateChangeValueDataUpdate"
+        - $ref: "#/components/schemas/StateChangeValueDataDeletion"
+    StateChangeValueAccessKeyUpdate:
+      additionalProperties: false
+      properties:
+        access_key:
+          additionalProperties: true
+          type: object
+        account_id:
+          type: string
+        public_key:
+          type: string
+      required:
+        - access_key
+        - account_id
+        - public_key
+      type: object
+    StateChangeValueAccountUpdate:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        amount:
+          type: string
+        code_hash:
+          type: string
+        locked:
+          type: string
+        storage_paid_at:
+          format: uint64
+          type: integer
+        storage_usage:
+          format: uint64
+          type: integer
+      required:
+        - account_id
+        - amount
+        - code_hash
+        - locked
+        - storage_paid_at
+        - storage_usage
+      type: object
+    StateChangeValueDataDeletion:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        key_base64:
+          type: string
+      required:
+        - account_id
+        - key_base64
+      type: object
+    StateChangeValueDataUpdate:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        key_base64:
+          type: string
+        value_base64:
+          type: string
+      required:
+        - account_id
+        - key_base64
+        - value_base64
       type: object

--- a/apis/neardata/v0/last_block_final.yaml
+++ b/apis/neardata/v0/last_block_final.yaml
@@ -20,10 +20,8 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
-                description: Full block document as served by neardata, including `block` and `shards`.
+                $ref: "#/components/schemas/BlockDocument"
                 nullable: true
-                type: object
           description: Full block document returned after automatic redirect following
         "302":
           description: Redirect to the latest block block URL
@@ -54,6 +52,81 @@ servers:
     url: https://testnet.neardata.xyz
 components:
   schemas:
+    ActionDocument:
+      additionalProperties: true
+      type: object
+    ActionReceiptBody:
+      additionalProperties: false
+      properties:
+        Action:
+          $ref: "#/components/schemas/ActionReceiptDocument"
+      required:
+        - Action
+      type: object
+    ActionReceiptDocument:
+      additionalProperties: false
+      properties:
+        actions:
+          items:
+            $ref: "#/components/schemas/ActionDocument"
+          type: array
+        gas_price:
+          type: string
+        input_data_ids:
+          items:
+            type: string
+          type: array
+        is_promise_yield:
+          type: boolean
+        output_data_receivers:
+          items:
+            $ref: "#/components/schemas/OutputDataReceiverDocument"
+          type: array
+        signer_id:
+          type: string
+        signer_public_key:
+          type: string
+      required:
+        - actions
+        - gas_price
+        - input_data_ids
+        - is_promise_yield
+        - output_data_receivers
+        - signer_id
+        - signer_public_key
+      type: object
+    BlockDocument:
+      additionalProperties: false
+      description: Full block document as served by neardata, including the block envelope and per-shard payloads.
+      properties:
+        block:
+          $ref: "#/components/schemas/BlockEnvelope"
+        shards:
+          items:
+            $ref: "#/components/schemas/ShardDocument"
+          type: array
+      required:
+        - block
+        - shards
+      type: object
+    BlockEnvelope:
+      additionalProperties: false
+      description: Block-level payload returned by neardata.
+      properties:
+        author:
+          description: Block producer account ID.
+          type: string
+        chunks:
+          items:
+            $ref: "#/components/schemas/ChunkHeader"
+          type: array
+        header:
+          $ref: "#/components/schemas/BlockHeader"
+      required:
+        - author
+        - chunks
+        - header
+      type: object
     BlockErrorResponse:
       additionalProperties: false
       properties:
@@ -71,6 +144,224 @@ components:
         - BLOCK_HEIGHT_TOO_LOW
         - BLOCK_DOES_NOT_EXIST
       type: string
+    BlockHeader:
+      additionalProperties: true
+      description: Block header object as served by neardata.
+      properties:
+        chunks_included:
+          format: uint64
+          type: integer
+        epoch_id:
+          type: string
+        gas_price:
+          type: string
+        hash:
+          type: string
+        height:
+          format: uint64
+          type: integer
+        next_epoch_id:
+          type: string
+        prev_hash:
+          type: string
+        prev_height:
+          format: uint64
+          type: integer
+        timestamp:
+          type: integer
+        timestamp_nanosec:
+          type: string
+        total_supply:
+          type: string
+      type: object
+    ChunkDocument:
+      additionalProperties: false
+      description: Chunk payload returned by neardata for a single shard in a selected block.
+      properties:
+        author:
+          description: Chunk producer account ID.
+          type: string
+        header:
+          $ref: "#/components/schemas/ChunkHeader"
+        receipts:
+          items:
+            $ref: "#/components/schemas/ReceiptDocument"
+          type: array
+        transactions:
+          items:
+            $ref: "#/components/schemas/ChunkTransactionWrapper"
+          type: array
+      required:
+        - author
+        - header
+        - receipts
+        - transactions
+      type: object
+    ChunkHeader:
+      additionalProperties: true
+      description: Chunk header object as served by neardata.
+      properties:
+        chunk_hash:
+          type: string
+        gas_limit:
+          type: integer
+        gas_used:
+          type: integer
+        height_created:
+          format: uint64
+          type: integer
+        height_included:
+          format: uint64
+          type: integer
+        outcome_root:
+          type: string
+        outgoing_receipts_root:
+          type: string
+        prev_block_hash:
+          type: string
+        shard_id:
+          format: uint64
+          type: integer
+        tx_root:
+          type: string
+      type: object
+    ChunkTransactionWrapper:
+      additionalProperties: false
+      description: Transaction entry returned inside a neardata chunk.
+      properties:
+        outcome:
+          $ref: "#/components/schemas/ExecutionWithReceipt"
+        transaction:
+          $ref: "#/components/schemas/SignedTransactionDocument"
+      required:
+        - outcome
+        - transaction
+      type: object
+    DataReceiptBody:
+      additionalProperties: false
+      properties:
+        Data:
+          $ref: "#/components/schemas/DataReceiptDocument"
+      required:
+        - Data
+      type: object
+    DataReceiptDocument:
+      additionalProperties: false
+      properties:
+        data:
+          type: string
+        data_id:
+          type: string
+        is_promise_resume:
+          type: boolean
+      required:
+        - data
+        - data_id
+        - is_promise_resume
+      type: object
+    ExecutionOutcomeDocument:
+      additionalProperties: false
+      properties:
+        block_hash:
+          type: string
+        id:
+          type: string
+        outcome:
+          $ref: "#/components/schemas/ExecutionOutcomeSummary"
+        proof:
+          items:
+            $ref: "#/components/schemas/ExecutionProofItem"
+          type: array
+      required:
+        - block_hash
+        - id
+        - outcome
+        - proof
+      type: object
+    ExecutionOutcomeStatus:
+      oneOf:
+        - $ref: "#/components/schemas/ExecutionOutcomeStatusSuccessReceiptId"
+        - $ref: "#/components/schemas/ExecutionOutcomeStatusSuccessValue"
+        - $ref: "#/components/schemas/ExecutionOutcomeStatusFailure"
+    ExecutionOutcomeStatusFailure:
+      additionalProperties: false
+      properties:
+        Failure:
+          additionalProperties: true
+          type: object
+      required:
+        - Failure
+      type: object
+    ExecutionOutcomeStatusSuccessReceiptId:
+      additionalProperties: false
+      properties:
+        SuccessReceiptId:
+          type: string
+      required:
+        - SuccessReceiptId
+      type: object
+    ExecutionOutcomeStatusSuccessValue:
+      additionalProperties: false
+      properties:
+        SuccessValue:
+          type: string
+      required:
+        - SuccessValue
+      type: object
+    ExecutionOutcomeSummary:
+      additionalProperties: false
+      properties:
+        executor_id:
+          type: string
+        gas_burnt:
+          format: uint64
+          type: integer
+        logs:
+          items:
+            type: string
+          type: array
+        metadata:
+          additionalProperties: true
+          type: object
+        receipt_ids:
+          items:
+            type: string
+          type: array
+        status:
+          $ref: "#/components/schemas/ExecutionOutcomeStatus"
+        tokens_burnt:
+          type: string
+      required:
+        - executor_id
+        - gas_burnt
+        - logs
+        - metadata
+        - receipt_ids
+        - status
+        - tokens_burnt
+      type: object
+    ExecutionProofItem:
+      additionalProperties: true
+      type: object
+    ExecutionWithReceipt:
+      additionalProperties: false
+      description: Execution result paired with an optional receipt object.
+      properties:
+        execution_outcome:
+          $ref: "#/components/schemas/ExecutionOutcomeDocument"
+        receipt:
+          description: Receipt payload when neardata includes it for this entry.
+          nullable: true
+          oneOf:
+            - $ref: "#/components/schemas/ReceiptDocument"
+            - $ref: "#/components/schemas/OmittedReceiptDocument"
+          type: object
+        tx_hash:
+          type: string
+      required:
+        - execution_outcome
+        - receipt
+      type: object
     HealthResponse:
       additionalProperties: false
       properties:
@@ -78,4 +369,224 @@ components:
           type: string
       required:
         - status
+      type: object
+    OmittedReceiptDocument:
+      additionalProperties: false
+      type: object
+    OutputDataReceiverDocument:
+      additionalProperties: false
+      properties:
+        data_id:
+          type: string
+        receiver_id:
+          type: string
+      required:
+        - data_id
+        - receiver_id
+      type: object
+    ReceiptBody:
+      oneOf:
+        - $ref: "#/components/schemas/ActionReceiptBody"
+        - $ref: "#/components/schemas/DataReceiptBody"
+    ReceiptDocument:
+      additionalProperties: false
+      description: Receipt object as served by neardata inside a chunk payload.
+      properties:
+        predecessor_id:
+          type: string
+        priority:
+          format: uint64
+          type: integer
+        receipt:
+          $ref: "#/components/schemas/ReceiptBody"
+        receipt_id:
+          type: string
+        receiver_id:
+          type: string
+      required:
+        - predecessor_id
+        - priority
+        - receipt
+        - receipt_id
+        - receiver_id
+      type: object
+    ShardDocument:
+      additionalProperties: false
+      description: Per-shard payload returned by neardata for a block.
+      properties:
+        chunk:
+          $ref: "#/components/schemas/ChunkDocument"
+        receipt_execution_outcomes:
+          items:
+            $ref: "#/components/schemas/ExecutionWithReceipt"
+          type: array
+        shard_id:
+          format: uint64
+          type: integer
+        state_changes:
+          items:
+            $ref: "#/components/schemas/StateChangeItem"
+          type: array
+      required:
+        - chunk
+        - receipt_execution_outcomes
+        - shard_id
+        - state_changes
+      type: object
+    SignedTransactionDocument:
+      additionalProperties: false
+      properties:
+        actions:
+          items:
+            $ref: "#/components/schemas/ActionDocument"
+          type: array
+        hash:
+          type: string
+        nonce:
+          format: uint64
+          type: integer
+        priority_fee:
+          format: uint64
+          type: integer
+        public_key:
+          type: string
+        receiver_id:
+          type: string
+        signature:
+          type: string
+        signer_id:
+          type: string
+      required:
+        - actions
+        - hash
+        - nonce
+        - priority_fee
+        - public_key
+        - receiver_id
+        - signature
+        - signer_id
+      type: object
+    StateChangeCause:
+      oneOf:
+        - $ref: "#/components/schemas/StateChangeCauseTransactionProcessing"
+        - $ref: "#/components/schemas/StateChangeCauseReceiptProcessing"
+        - $ref: "#/components/schemas/StateChangeCauseActionReceiptGasReward"
+    StateChangeCauseActionReceiptGasReward:
+      additionalProperties: false
+      properties:
+        receipt_hash:
+          type: string
+        type:
+          type: string
+      required:
+        - receipt_hash
+        - type
+      type: object
+    StateChangeCauseReceiptProcessing:
+      additionalProperties: false
+      properties:
+        receipt_hash:
+          type: string
+        type:
+          type: string
+      required:
+        - receipt_hash
+        - type
+      type: object
+    StateChangeCauseTransactionProcessing:
+      additionalProperties: false
+      properties:
+        tx_hash:
+          type: string
+        type:
+          type: string
+      required:
+        - tx_hash
+        - type
+      type: object
+    StateChangeItem:
+      additionalProperties: false
+      description: State change entry returned by neardata for a shard.
+      properties:
+        cause:
+          $ref: "#/components/schemas/StateChangeCause"
+        change:
+          $ref: "#/components/schemas/StateChangeValue"
+        type:
+          type: string
+      required:
+        - cause
+        - change
+        - type
+      type: object
+    StateChangeValue:
+      oneOf:
+        - $ref: "#/components/schemas/StateChangeValueAccountUpdate"
+        - $ref: "#/components/schemas/StateChangeValueAccessKeyUpdate"
+        - $ref: "#/components/schemas/StateChangeValueDataUpdate"
+        - $ref: "#/components/schemas/StateChangeValueDataDeletion"
+    StateChangeValueAccessKeyUpdate:
+      additionalProperties: false
+      properties:
+        access_key:
+          additionalProperties: true
+          type: object
+        account_id:
+          type: string
+        public_key:
+          type: string
+      required:
+        - access_key
+        - account_id
+        - public_key
+      type: object
+    StateChangeValueAccountUpdate:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        amount:
+          type: string
+        code_hash:
+          type: string
+        locked:
+          type: string
+        storage_paid_at:
+          format: uint64
+          type: integer
+        storage_usage:
+          format: uint64
+          type: integer
+      required:
+        - account_id
+        - amount
+        - code_hash
+        - locked
+        - storage_paid_at
+        - storage_usage
+      type: object
+    StateChangeValueDataDeletion:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        key_base64:
+          type: string
+      required:
+        - account_id
+        - key_base64
+      type: object
+    StateChangeValueDataUpdate:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        key_base64:
+          type: string
+        value_base64:
+          type: string
+      required:
+        - account_id
+        - key_base64
+        - value_base64
       type: object

--- a/apis/neardata/v0/last_block_optimistic.yaml
+++ b/apis/neardata/v0/last_block_optimistic.yaml
@@ -20,10 +20,8 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
-                description: Full block document as served by neardata, including `block` and `shards`.
+                $ref: "#/components/schemas/BlockDocument"
                 nullable: true
-                type: object
           description: Full block document returned after automatic redirect following
         "302":
           description: Redirect to the latest block block URL
@@ -54,6 +52,81 @@ servers:
     url: https://testnet.neardata.xyz
 components:
   schemas:
+    ActionDocument:
+      additionalProperties: true
+      type: object
+    ActionReceiptBody:
+      additionalProperties: false
+      properties:
+        Action:
+          $ref: "#/components/schemas/ActionReceiptDocument"
+      required:
+        - Action
+      type: object
+    ActionReceiptDocument:
+      additionalProperties: false
+      properties:
+        actions:
+          items:
+            $ref: "#/components/schemas/ActionDocument"
+          type: array
+        gas_price:
+          type: string
+        input_data_ids:
+          items:
+            type: string
+          type: array
+        is_promise_yield:
+          type: boolean
+        output_data_receivers:
+          items:
+            $ref: "#/components/schemas/OutputDataReceiverDocument"
+          type: array
+        signer_id:
+          type: string
+        signer_public_key:
+          type: string
+      required:
+        - actions
+        - gas_price
+        - input_data_ids
+        - is_promise_yield
+        - output_data_receivers
+        - signer_id
+        - signer_public_key
+      type: object
+    BlockDocument:
+      additionalProperties: false
+      description: Full block document as served by neardata, including the block envelope and per-shard payloads.
+      properties:
+        block:
+          $ref: "#/components/schemas/BlockEnvelope"
+        shards:
+          items:
+            $ref: "#/components/schemas/ShardDocument"
+          type: array
+      required:
+        - block
+        - shards
+      type: object
+    BlockEnvelope:
+      additionalProperties: false
+      description: Block-level payload returned by neardata.
+      properties:
+        author:
+          description: Block producer account ID.
+          type: string
+        chunks:
+          items:
+            $ref: "#/components/schemas/ChunkHeader"
+          type: array
+        header:
+          $ref: "#/components/schemas/BlockHeader"
+      required:
+        - author
+        - chunks
+        - header
+      type: object
     BlockErrorResponse:
       additionalProperties: false
       properties:
@@ -71,6 +144,224 @@ components:
         - BLOCK_HEIGHT_TOO_LOW
         - BLOCK_DOES_NOT_EXIST
       type: string
+    BlockHeader:
+      additionalProperties: true
+      description: Block header object as served by neardata.
+      properties:
+        chunks_included:
+          format: uint64
+          type: integer
+        epoch_id:
+          type: string
+        gas_price:
+          type: string
+        hash:
+          type: string
+        height:
+          format: uint64
+          type: integer
+        next_epoch_id:
+          type: string
+        prev_hash:
+          type: string
+        prev_height:
+          format: uint64
+          type: integer
+        timestamp:
+          type: integer
+        timestamp_nanosec:
+          type: string
+        total_supply:
+          type: string
+      type: object
+    ChunkDocument:
+      additionalProperties: false
+      description: Chunk payload returned by neardata for a single shard in a selected block.
+      properties:
+        author:
+          description: Chunk producer account ID.
+          type: string
+        header:
+          $ref: "#/components/schemas/ChunkHeader"
+        receipts:
+          items:
+            $ref: "#/components/schemas/ReceiptDocument"
+          type: array
+        transactions:
+          items:
+            $ref: "#/components/schemas/ChunkTransactionWrapper"
+          type: array
+      required:
+        - author
+        - header
+        - receipts
+        - transactions
+      type: object
+    ChunkHeader:
+      additionalProperties: true
+      description: Chunk header object as served by neardata.
+      properties:
+        chunk_hash:
+          type: string
+        gas_limit:
+          type: integer
+        gas_used:
+          type: integer
+        height_created:
+          format: uint64
+          type: integer
+        height_included:
+          format: uint64
+          type: integer
+        outcome_root:
+          type: string
+        outgoing_receipts_root:
+          type: string
+        prev_block_hash:
+          type: string
+        shard_id:
+          format: uint64
+          type: integer
+        tx_root:
+          type: string
+      type: object
+    ChunkTransactionWrapper:
+      additionalProperties: false
+      description: Transaction entry returned inside a neardata chunk.
+      properties:
+        outcome:
+          $ref: "#/components/schemas/ExecutionWithReceipt"
+        transaction:
+          $ref: "#/components/schemas/SignedTransactionDocument"
+      required:
+        - outcome
+        - transaction
+      type: object
+    DataReceiptBody:
+      additionalProperties: false
+      properties:
+        Data:
+          $ref: "#/components/schemas/DataReceiptDocument"
+      required:
+        - Data
+      type: object
+    DataReceiptDocument:
+      additionalProperties: false
+      properties:
+        data:
+          type: string
+        data_id:
+          type: string
+        is_promise_resume:
+          type: boolean
+      required:
+        - data
+        - data_id
+        - is_promise_resume
+      type: object
+    ExecutionOutcomeDocument:
+      additionalProperties: false
+      properties:
+        block_hash:
+          type: string
+        id:
+          type: string
+        outcome:
+          $ref: "#/components/schemas/ExecutionOutcomeSummary"
+        proof:
+          items:
+            $ref: "#/components/schemas/ExecutionProofItem"
+          type: array
+      required:
+        - block_hash
+        - id
+        - outcome
+        - proof
+      type: object
+    ExecutionOutcomeStatus:
+      oneOf:
+        - $ref: "#/components/schemas/ExecutionOutcomeStatusSuccessReceiptId"
+        - $ref: "#/components/schemas/ExecutionOutcomeStatusSuccessValue"
+        - $ref: "#/components/schemas/ExecutionOutcomeStatusFailure"
+    ExecutionOutcomeStatusFailure:
+      additionalProperties: false
+      properties:
+        Failure:
+          additionalProperties: true
+          type: object
+      required:
+        - Failure
+      type: object
+    ExecutionOutcomeStatusSuccessReceiptId:
+      additionalProperties: false
+      properties:
+        SuccessReceiptId:
+          type: string
+      required:
+        - SuccessReceiptId
+      type: object
+    ExecutionOutcomeStatusSuccessValue:
+      additionalProperties: false
+      properties:
+        SuccessValue:
+          type: string
+      required:
+        - SuccessValue
+      type: object
+    ExecutionOutcomeSummary:
+      additionalProperties: false
+      properties:
+        executor_id:
+          type: string
+        gas_burnt:
+          format: uint64
+          type: integer
+        logs:
+          items:
+            type: string
+          type: array
+        metadata:
+          additionalProperties: true
+          type: object
+        receipt_ids:
+          items:
+            type: string
+          type: array
+        status:
+          $ref: "#/components/schemas/ExecutionOutcomeStatus"
+        tokens_burnt:
+          type: string
+      required:
+        - executor_id
+        - gas_burnt
+        - logs
+        - metadata
+        - receipt_ids
+        - status
+        - tokens_burnt
+      type: object
+    ExecutionProofItem:
+      additionalProperties: true
+      type: object
+    ExecutionWithReceipt:
+      additionalProperties: false
+      description: Execution result paired with an optional receipt object.
+      properties:
+        execution_outcome:
+          $ref: "#/components/schemas/ExecutionOutcomeDocument"
+        receipt:
+          description: Receipt payload when neardata includes it for this entry.
+          nullable: true
+          oneOf:
+            - $ref: "#/components/schemas/ReceiptDocument"
+            - $ref: "#/components/schemas/OmittedReceiptDocument"
+          type: object
+        tx_hash:
+          type: string
+      required:
+        - execution_outcome
+        - receipt
+      type: object
     HealthResponse:
       additionalProperties: false
       properties:
@@ -78,4 +369,224 @@ components:
           type: string
       required:
         - status
+      type: object
+    OmittedReceiptDocument:
+      additionalProperties: false
+      type: object
+    OutputDataReceiverDocument:
+      additionalProperties: false
+      properties:
+        data_id:
+          type: string
+        receiver_id:
+          type: string
+      required:
+        - data_id
+        - receiver_id
+      type: object
+    ReceiptBody:
+      oneOf:
+        - $ref: "#/components/schemas/ActionReceiptBody"
+        - $ref: "#/components/schemas/DataReceiptBody"
+    ReceiptDocument:
+      additionalProperties: false
+      description: Receipt object as served by neardata inside a chunk payload.
+      properties:
+        predecessor_id:
+          type: string
+        priority:
+          format: uint64
+          type: integer
+        receipt:
+          $ref: "#/components/schemas/ReceiptBody"
+        receipt_id:
+          type: string
+        receiver_id:
+          type: string
+      required:
+        - predecessor_id
+        - priority
+        - receipt
+        - receipt_id
+        - receiver_id
+      type: object
+    ShardDocument:
+      additionalProperties: false
+      description: Per-shard payload returned by neardata for a block.
+      properties:
+        chunk:
+          $ref: "#/components/schemas/ChunkDocument"
+        receipt_execution_outcomes:
+          items:
+            $ref: "#/components/schemas/ExecutionWithReceipt"
+          type: array
+        shard_id:
+          format: uint64
+          type: integer
+        state_changes:
+          items:
+            $ref: "#/components/schemas/StateChangeItem"
+          type: array
+      required:
+        - chunk
+        - receipt_execution_outcomes
+        - shard_id
+        - state_changes
+      type: object
+    SignedTransactionDocument:
+      additionalProperties: false
+      properties:
+        actions:
+          items:
+            $ref: "#/components/schemas/ActionDocument"
+          type: array
+        hash:
+          type: string
+        nonce:
+          format: uint64
+          type: integer
+        priority_fee:
+          format: uint64
+          type: integer
+        public_key:
+          type: string
+        receiver_id:
+          type: string
+        signature:
+          type: string
+        signer_id:
+          type: string
+      required:
+        - actions
+        - hash
+        - nonce
+        - priority_fee
+        - public_key
+        - receiver_id
+        - signature
+        - signer_id
+      type: object
+    StateChangeCause:
+      oneOf:
+        - $ref: "#/components/schemas/StateChangeCauseTransactionProcessing"
+        - $ref: "#/components/schemas/StateChangeCauseReceiptProcessing"
+        - $ref: "#/components/schemas/StateChangeCauseActionReceiptGasReward"
+    StateChangeCauseActionReceiptGasReward:
+      additionalProperties: false
+      properties:
+        receipt_hash:
+          type: string
+        type:
+          type: string
+      required:
+        - receipt_hash
+        - type
+      type: object
+    StateChangeCauseReceiptProcessing:
+      additionalProperties: false
+      properties:
+        receipt_hash:
+          type: string
+        type:
+          type: string
+      required:
+        - receipt_hash
+        - type
+      type: object
+    StateChangeCauseTransactionProcessing:
+      additionalProperties: false
+      properties:
+        tx_hash:
+          type: string
+        type:
+          type: string
+      required:
+        - tx_hash
+        - type
+      type: object
+    StateChangeItem:
+      additionalProperties: false
+      description: State change entry returned by neardata for a shard.
+      properties:
+        cause:
+          $ref: "#/components/schemas/StateChangeCause"
+        change:
+          $ref: "#/components/schemas/StateChangeValue"
+        type:
+          type: string
+      required:
+        - cause
+        - change
+        - type
+      type: object
+    StateChangeValue:
+      oneOf:
+        - $ref: "#/components/schemas/StateChangeValueAccountUpdate"
+        - $ref: "#/components/schemas/StateChangeValueAccessKeyUpdate"
+        - $ref: "#/components/schemas/StateChangeValueDataUpdate"
+        - $ref: "#/components/schemas/StateChangeValueDataDeletion"
+    StateChangeValueAccessKeyUpdate:
+      additionalProperties: false
+      properties:
+        access_key:
+          additionalProperties: true
+          type: object
+        account_id:
+          type: string
+        public_key:
+          type: string
+      required:
+        - access_key
+        - account_id
+        - public_key
+      type: object
+    StateChangeValueAccountUpdate:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        amount:
+          type: string
+        code_hash:
+          type: string
+        locked:
+          type: string
+        storage_paid_at:
+          format: uint64
+          type: integer
+        storage_usage:
+          format: uint64
+          type: integer
+      required:
+        - account_id
+        - amount
+        - code_hash
+        - locked
+        - storage_paid_at
+        - storage_usage
+      type: object
+    StateChangeValueDataDeletion:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        key_base64:
+          type: string
+      required:
+        - account_id
+        - key_base64
+      type: object
+    StateChangeValueDataUpdate:
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+        key_base64:
+          type: string
+        value_base64:
+          type: string
+      required:
+        - account_id
+        - key_base64
+        - value_base64
       type: object

--- a/shared/generatedFastnearPageModels.json
+++ b/shared/generatedFastnearPageModels.json
@@ -20764,8 +20764,1804 @@
         "mediaType": "application/json",
         "schema": {
           "type": "object",
-          "description": "Full block document as served by neardata, including `block` and `shards`.",
-          "additionalProperties": true
+          "description": "Full block document as served by neardata, including the block envelope and per-shard payloads.",
+          "required": [
+            "block",
+            "shards"
+          ],
+          "additionalProperties": false,
+          "properties": [
+            {
+              "name": "block",
+              "required": true,
+              "schema": {
+                "type": "object",
+                "description": "Block-level payload returned by neardata.",
+                "required": [
+                  "author",
+                  "chunks",
+                  "header"
+                ],
+                "additionalProperties": false,
+                "properties": [
+                  {
+                    "name": "author",
+                    "required": true,
+                    "schema": {
+                      "type": "string",
+                      "description": "Block producer account ID."
+                    }
+                  },
+                  {
+                    "name": "chunks",
+                    "required": true,
+                    "schema": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "description": "Chunk header object as served by neardata.",
+                        "additionalProperties": true,
+                        "properties": [
+                          {
+                            "name": "chunk_hash",
+                            "required": false,
+                            "schema": {
+                              "type": "string"
+                            }
+                          },
+                          {
+                            "name": "gas_limit",
+                            "required": false,
+                            "schema": {
+                              "type": "integer"
+                            }
+                          },
+                          {
+                            "name": "gas_used",
+                            "required": false,
+                            "schema": {
+                              "type": "integer"
+                            }
+                          },
+                          {
+                            "name": "height_created",
+                            "required": false,
+                            "schema": {
+                              "type": "integer",
+                              "format": "uint64"
+                            }
+                          },
+                          {
+                            "name": "height_included",
+                            "required": false,
+                            "schema": {
+                              "type": "integer",
+                              "format": "uint64"
+                            }
+                          },
+                          {
+                            "name": "outcome_root",
+                            "required": false,
+                            "schema": {
+                              "type": "string"
+                            }
+                          },
+                          {
+                            "name": "outgoing_receipts_root",
+                            "required": false,
+                            "schema": {
+                              "type": "string"
+                            }
+                          },
+                          {
+                            "name": "prev_block_hash",
+                            "required": false,
+                            "schema": {
+                              "type": "string"
+                            }
+                          },
+                          {
+                            "name": "shard_id",
+                            "required": false,
+                            "schema": {
+                              "type": "integer",
+                              "format": "uint64"
+                            }
+                          },
+                          {
+                            "name": "tx_root",
+                            "required": false,
+                            "schema": {
+                              "type": "string"
+                            }
+                          }
+                        ],
+                        "refName": "ChunkHeader"
+                      }
+                    }
+                  },
+                  {
+                    "name": "header",
+                    "required": true,
+                    "schema": {
+                      "type": "object",
+                      "description": "Block header object as served by neardata.",
+                      "additionalProperties": true,
+                      "properties": [
+                        {
+                          "name": "chunks_included",
+                          "required": false,
+                          "schema": {
+                            "type": "integer",
+                            "format": "uint64"
+                          }
+                        },
+                        {
+                          "name": "epoch_id",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "name": "gas_price",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "name": "hash",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "name": "height",
+                          "required": false,
+                          "schema": {
+                            "type": "integer",
+                            "format": "uint64"
+                          }
+                        },
+                        {
+                          "name": "next_epoch_id",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "name": "prev_hash",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "name": "prev_height",
+                          "required": false,
+                          "schema": {
+                            "type": "integer",
+                            "format": "uint64"
+                          }
+                        },
+                        {
+                          "name": "timestamp",
+                          "required": false,
+                          "schema": {
+                            "type": "integer"
+                          }
+                        },
+                        {
+                          "name": "timestamp_nanosec",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "name": "total_supply",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        }
+                      ],
+                      "refName": "BlockHeader"
+                    }
+                  }
+                ],
+                "refName": "BlockEnvelope"
+              }
+            },
+            {
+              "name": "shards",
+              "required": true,
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "description": "Per-shard payload returned by neardata for a block.",
+                  "required": [
+                    "chunk",
+                    "receipt_execution_outcomes",
+                    "shard_id",
+                    "state_changes"
+                  ],
+                  "additionalProperties": false,
+                  "properties": [
+                    {
+                      "name": "chunk",
+                      "required": true,
+                      "schema": {
+                        "type": "object",
+                        "description": "Chunk payload returned by neardata for a single shard in a selected block.",
+                        "required": [
+                          "author",
+                          "header",
+                          "receipts",
+                          "transactions"
+                        ],
+                        "additionalProperties": false,
+                        "properties": [
+                          {
+                            "name": "author",
+                            "required": true,
+                            "schema": {
+                              "type": "string",
+                              "description": "Chunk producer account ID."
+                            }
+                          },
+                          {
+                            "name": "header",
+                            "required": true,
+                            "schema": {
+                              "type": "object",
+                              "description": "Chunk header object as served by neardata.",
+                              "additionalProperties": true,
+                              "properties": [
+                                {
+                                  "name": "chunk_hash",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "string"
+                                  }
+                                },
+                                {
+                                  "name": "gas_limit",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "integer"
+                                  }
+                                },
+                                {
+                                  "name": "gas_used",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "integer"
+                                  }
+                                },
+                                {
+                                  "name": "height_created",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "integer",
+                                    "format": "uint64"
+                                  }
+                                },
+                                {
+                                  "name": "height_included",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "integer",
+                                    "format": "uint64"
+                                  }
+                                },
+                                {
+                                  "name": "outcome_root",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "string"
+                                  }
+                                },
+                                {
+                                  "name": "outgoing_receipts_root",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "string"
+                                  }
+                                },
+                                {
+                                  "name": "prev_block_hash",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "string"
+                                  }
+                                },
+                                {
+                                  "name": "shard_id",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "integer",
+                                    "format": "uint64"
+                                  }
+                                },
+                                {
+                                  "name": "tx_root",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "string"
+                                  }
+                                }
+                              ],
+                              "refName": "ChunkHeader"
+                            }
+                          },
+                          {
+                            "name": "receipts",
+                            "required": true,
+                            "schema": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "description": "Receipt object as served by neardata inside a chunk payload.",
+                                "required": [
+                                  "predecessor_id",
+                                  "priority",
+                                  "receipt",
+                                  "receipt_id",
+                                  "receiver_id"
+                                ],
+                                "additionalProperties": false,
+                                "properties": [
+                                  {
+                                    "name": "predecessor_id",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  {
+                                    "name": "priority",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "integer",
+                                      "format": "uint64"
+                                    }
+                                  },
+                                  {
+                                    "name": "receipt",
+                                    "required": true,
+                                    "schema": {
+                                      "oneOf": [
+                                        {
+                                          "type": "object",
+                                          "required": [
+                                            "Action"
+                                          ],
+                                          "additionalProperties": false,
+                                          "properties": [
+                                            {
+                                              "name": "Action",
+                                              "required": true,
+                                              "schema": {
+                                                "type": "object",
+                                                "required": [
+                                                  "actions",
+                                                  "gas_price",
+                                                  "input_data_ids",
+                                                  "is_promise_yield",
+                                                  "output_data_receivers",
+                                                  "signer_id",
+                                                  "signer_public_key"
+                                                ],
+                                                "additionalProperties": false,
+                                                "properties": [
+                                                  {
+                                                    "name": "actions",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "object",
+                                                        "additionalProperties": true,
+                                                        "refName": "ActionDocument"
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "gas_price",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "input_data_ids",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "is_promise_yield",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "output_data_receivers",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "object",
+                                                        "required": [
+                                                          "data_id",
+                                                          "receiver_id"
+                                                        ],
+                                                        "additionalProperties": false,
+                                                        "properties": [
+                                                          {
+                                                            "name": "data_id",
+                                                            "required": true,
+                                                            "schema": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          {
+                                                            "name": "receiver_id",
+                                                            "required": true,
+                                                            "schema": {
+                                                              "type": "string"
+                                                            }
+                                                          }
+                                                        ],
+                                                        "refName": "OutputDataReceiverDocument"
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "signer_id",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "signer_public_key",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                ],
+                                                "refName": "ActionReceiptDocument"
+                                              }
+                                            }
+                                          ],
+                                          "refName": "ActionReceiptBody"
+                                        },
+                                        {
+                                          "type": "object",
+                                          "required": [
+                                            "Data"
+                                          ],
+                                          "additionalProperties": false,
+                                          "properties": [
+                                            {
+                                              "name": "Data",
+                                              "required": true,
+                                              "schema": {
+                                                "type": "object",
+                                                "required": [
+                                                  "data",
+                                                  "data_id",
+                                                  "is_promise_resume"
+                                                ],
+                                                "additionalProperties": false,
+                                                "properties": [
+                                                  {
+                                                    "name": "data",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "data_id",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "is_promise_resume",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "boolean"
+                                                    }
+                                                  }
+                                                ],
+                                                "refName": "DataReceiptDocument"
+                                              }
+                                            }
+                                          ],
+                                          "refName": "DataReceiptBody"
+                                        }
+                                      ],
+                                      "refName": "ReceiptBody"
+                                    }
+                                  },
+                                  {
+                                    "name": "receipt_id",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  {
+                                    "name": "receiver_id",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "string"
+                                    }
+                                  }
+                                ],
+                                "refName": "ReceiptDocument"
+                              }
+                            }
+                          },
+                          {
+                            "name": "transactions",
+                            "required": true,
+                            "schema": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "description": "Transaction entry returned inside a neardata chunk.",
+                                "required": [
+                                  "outcome",
+                                  "transaction"
+                                ],
+                                "additionalProperties": false,
+                                "properties": [
+                                  {
+                                    "name": "outcome",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "object",
+                                      "description": "Execution result paired with an optional receipt object.",
+                                      "required": [
+                                        "execution_outcome",
+                                        "receipt"
+                                      ],
+                                      "additionalProperties": false,
+                                      "properties": [
+                                        {
+                                          "name": "execution_outcome",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "object",
+                                            "required": [
+                                              "block_hash",
+                                              "id",
+                                              "outcome",
+                                              "proof"
+                                            ],
+                                            "additionalProperties": false,
+                                            "properties": [
+                                              {
+                                                "name": "block_hash",
+                                                "required": true,
+                                                "schema": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              {
+                                                "name": "id",
+                                                "required": true,
+                                                "schema": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              {
+                                                "name": "outcome",
+                                                "required": true,
+                                                "schema": {
+                                                  "type": "object",
+                                                  "required": [
+                                                    "executor_id",
+                                                    "gas_burnt",
+                                                    "logs",
+                                                    "metadata",
+                                                    "receipt_ids",
+                                                    "status",
+                                                    "tokens_burnt"
+                                                  ],
+                                                  "additionalProperties": false,
+                                                  "properties": [
+                                                    {
+                                                      "name": "executor_id",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "gas_burnt",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "integer",
+                                                        "format": "uint64"
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "logs",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "metadata",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "object",
+                                                        "additionalProperties": true
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "receipt_ids",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "status",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "oneOf": [
+                                                          {
+                                                            "type": "object",
+                                                            "required": [
+                                                              "SuccessReceiptId"
+                                                            ],
+                                                            "additionalProperties": false,
+                                                            "properties": [
+                                                              {
+                                                                "name": "SuccessReceiptId",
+                                                                "required": true,
+                                                                "schema": {
+                                                                  "type": "string"
+                                                                }
+                                                              }
+                                                            ],
+                                                            "refName": "ExecutionOutcomeStatusSuccessReceiptId"
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "required": [
+                                                              "SuccessValue"
+                                                            ],
+                                                            "additionalProperties": false,
+                                                            "properties": [
+                                                              {
+                                                                "name": "SuccessValue",
+                                                                "required": true,
+                                                                "schema": {
+                                                                  "type": "string"
+                                                                }
+                                                              }
+                                                            ],
+                                                            "refName": "ExecutionOutcomeStatusSuccessValue"
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "required": [
+                                                              "Failure"
+                                                            ],
+                                                            "additionalProperties": false,
+                                                            "properties": [
+                                                              {
+                                                                "name": "Failure",
+                                                                "required": true,
+                                                                "schema": {
+                                                                  "type": "object",
+                                                                  "additionalProperties": true
+                                                                }
+                                                              }
+                                                            ],
+                                                            "refName": "ExecutionOutcomeStatusFailure"
+                                                          }
+                                                        ],
+                                                        "refName": "ExecutionOutcomeStatus"
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "tokens_burnt",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  ],
+                                                  "refName": "ExecutionOutcomeSummary"
+                                                }
+                                              },
+                                              {
+                                                "name": "proof",
+                                                "required": true,
+                                                "schema": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "object",
+                                                    "additionalProperties": true,
+                                                    "refName": "ExecutionProofItem"
+                                                  }
+                                                }
+                                              }
+                                            ],
+                                            "refName": "ExecutionOutcomeDocument"
+                                          }
+                                        },
+                                        {
+                                          "name": "receipt",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "object",
+                                            "description": "Receipt payload when neardata includes it for this entry.",
+                                            "oneOf": [
+                                              {
+                                                "type": "object",
+                                                "description": "Receipt object as served by neardata inside a chunk payload.",
+                                                "required": [
+                                                  "predecessor_id",
+                                                  "priority",
+                                                  "receipt",
+                                                  "receipt_id",
+                                                  "receiver_id"
+                                                ],
+                                                "additionalProperties": false,
+                                                "properties": [
+                                                  {
+                                                    "name": "predecessor_id",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "priority",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "integer",
+                                                      "format": "uint64"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "receipt",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "oneOf": [
+                                                        {
+                                                          "type": "object",
+                                                          "required": [
+                                                            "Action"
+                                                          ],
+                                                          "additionalProperties": false,
+                                                          "properties": [
+                                                            {
+                                                              "name": "Action",
+                                                              "required": true,
+                                                              "schema": {
+                                                                "type": "object",
+                                                                "required": [
+                                                                  "actions",
+                                                                  "gas_price",
+                                                                  "input_data_ids",
+                                                                  "is_promise_yield",
+                                                                  "output_data_receivers",
+                                                                  "signer_id",
+                                                                  "signer_public_key"
+                                                                ],
+                                                                "additionalProperties": false,
+                                                                "properties": [
+                                                                  {
+                                                                    "name": "actions",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "array",
+                                                                      "items": {
+                                                                        "type": "object",
+                                                                        "additionalProperties": true,
+                                                                        "refName": "ActionDocument"
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "gas_price",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "input_data_ids",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "array",
+                                                                      "items": {
+                                                                        "type": "string"
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "is_promise_yield",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "boolean"
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "output_data_receivers",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "array",
+                                                                      "items": {
+                                                                        "type": "object",
+                                                                        "required": [
+                                                                          "data_id",
+                                                                          "receiver_id"
+                                                                        ],
+                                                                        "additionalProperties": false,
+                                                                        "properties": [
+                                                                          {
+                                                                            "name": "data_id",
+                                                                            "required": true,
+                                                                            "schema": {
+                                                                              "type": "string"
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "name": "receiver_id",
+                                                                            "required": true,
+                                                                            "schema": {
+                                                                              "type": "string"
+                                                                            }
+                                                                          }
+                                                                        ],
+                                                                        "refName": "OutputDataReceiverDocument"
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "signer_id",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "signer_public_key",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  }
+                                                                ],
+                                                                "refName": "ActionReceiptDocument"
+                                                              }
+                                                            }
+                                                          ],
+                                                          "refName": "ActionReceiptBody"
+                                                        },
+                                                        {
+                                                          "type": "object",
+                                                          "required": [
+                                                            "Data"
+                                                          ],
+                                                          "additionalProperties": false,
+                                                          "properties": [
+                                                            {
+                                                              "name": "Data",
+                                                              "required": true,
+                                                              "schema": {
+                                                                "type": "object",
+                                                                "required": [
+                                                                  "data",
+                                                                  "data_id",
+                                                                  "is_promise_resume"
+                                                                ],
+                                                                "additionalProperties": false,
+                                                                "properties": [
+                                                                  {
+                                                                    "name": "data",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "data_id",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "is_promise_resume",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "boolean"
+                                                                    }
+                                                                  }
+                                                                ],
+                                                                "refName": "DataReceiptDocument"
+                                                              }
+                                                            }
+                                                          ],
+                                                          "refName": "DataReceiptBody"
+                                                        }
+                                                      ],
+                                                      "refName": "ReceiptBody"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "receipt_id",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "receiver_id",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                ],
+                                                "refName": "ReceiptDocument"
+                                              },
+                                              {
+                                                "type": "object",
+                                                "additionalProperties": false,
+                                                "refName": "OmittedReceiptDocument"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "name": "tx_hash",
+                                          "required": false,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      ],
+                                      "refName": "ExecutionWithReceipt"
+                                    }
+                                  },
+                                  {
+                                    "name": "transaction",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "object",
+                                      "required": [
+                                        "actions",
+                                        "hash",
+                                        "nonce",
+                                        "priority_fee",
+                                        "public_key",
+                                        "receiver_id",
+                                        "signature",
+                                        "signer_id"
+                                      ],
+                                      "additionalProperties": false,
+                                      "properties": [
+                                        {
+                                          "name": "actions",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "additionalProperties": true,
+                                              "refName": "ActionDocument"
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "name": "hash",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        {
+                                          "name": "nonce",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "integer",
+                                            "format": "uint64"
+                                          }
+                                        },
+                                        {
+                                          "name": "priority_fee",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "integer",
+                                            "format": "uint64"
+                                          }
+                                        },
+                                        {
+                                          "name": "public_key",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        {
+                                          "name": "receiver_id",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        {
+                                          "name": "signature",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        {
+                                          "name": "signer_id",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      ],
+                                      "refName": "SignedTransactionDocument"
+                                    }
+                                  }
+                                ],
+                                "refName": "ChunkTransactionWrapper"
+                              }
+                            }
+                          }
+                        ],
+                        "refName": "ChunkDocument"
+                      }
+                    },
+                    {
+                      "name": "receipt_execution_outcomes",
+                      "required": true,
+                      "schema": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "description": "Execution result paired with an optional receipt object.",
+                          "required": [
+                            "execution_outcome",
+                            "receipt"
+                          ],
+                          "additionalProperties": false,
+                          "properties": [
+                            {
+                              "name": "execution_outcome",
+                              "required": true,
+                              "schema": {
+                                "type": "object",
+                                "required": [
+                                  "block_hash",
+                                  "id",
+                                  "outcome",
+                                  "proof"
+                                ],
+                                "additionalProperties": false,
+                                "properties": [
+                                  {
+                                    "name": "block_hash",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  {
+                                    "name": "id",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  {
+                                    "name": "outcome",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "object",
+                                      "required": [
+                                        "executor_id",
+                                        "gas_burnt",
+                                        "logs",
+                                        "metadata",
+                                        "receipt_ids",
+                                        "status",
+                                        "tokens_burnt"
+                                      ],
+                                      "additionalProperties": false,
+                                      "properties": [
+                                        {
+                                          "name": "executor_id",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        {
+                                          "name": "gas_burnt",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "integer",
+                                            "format": "uint64"
+                                          }
+                                        },
+                                        {
+                                          "name": "logs",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "name": "metadata",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "object",
+                                            "additionalProperties": true
+                                          }
+                                        },
+                                        {
+                                          "name": "receipt_ids",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "name": "status",
+                                          "required": true,
+                                          "schema": {
+                                            "oneOf": [
+                                              {
+                                                "type": "object",
+                                                "required": [
+                                                  "SuccessReceiptId"
+                                                ],
+                                                "additionalProperties": false,
+                                                "properties": [
+                                                  {
+                                                    "name": "SuccessReceiptId",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                ],
+                                                "refName": "ExecutionOutcomeStatusSuccessReceiptId"
+                                              },
+                                              {
+                                                "type": "object",
+                                                "required": [
+                                                  "SuccessValue"
+                                                ],
+                                                "additionalProperties": false,
+                                                "properties": [
+                                                  {
+                                                    "name": "SuccessValue",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                ],
+                                                "refName": "ExecutionOutcomeStatusSuccessValue"
+                                              },
+                                              {
+                                                "type": "object",
+                                                "required": [
+                                                  "Failure"
+                                                ],
+                                                "additionalProperties": false,
+                                                "properties": [
+                                                  {
+                                                    "name": "Failure",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "object",
+                                                      "additionalProperties": true
+                                                    }
+                                                  }
+                                                ],
+                                                "refName": "ExecutionOutcomeStatusFailure"
+                                              }
+                                            ],
+                                            "refName": "ExecutionOutcomeStatus"
+                                          }
+                                        },
+                                        {
+                                          "name": "tokens_burnt",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      ],
+                                      "refName": "ExecutionOutcomeSummary"
+                                    }
+                                  },
+                                  {
+                                    "name": "proof",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "additionalProperties": true,
+                                        "refName": "ExecutionProofItem"
+                                      }
+                                    }
+                                  }
+                                ],
+                                "refName": "ExecutionOutcomeDocument"
+                              }
+                            },
+                            {
+                              "name": "receipt",
+                              "required": true,
+                              "schema": {
+                                "type": "object",
+                                "description": "Receipt payload when neardata includes it for this entry.",
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "description": "Receipt object as served by neardata inside a chunk payload.",
+                                    "required": [
+                                      "predecessor_id",
+                                      "priority",
+                                      "receipt",
+                                      "receipt_id",
+                                      "receiver_id"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "predecessor_id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "priority",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "integer",
+                                          "format": "uint64"
+                                        }
+                                      },
+                                      {
+                                        "name": "receipt",
+                                        "required": true,
+                                        "schema": {
+                                          "oneOf": [
+                                            {
+                                              "type": "object",
+                                              "required": [
+                                                "Action"
+                                              ],
+                                              "additionalProperties": false,
+                                              "properties": [
+                                                {
+                                                  "name": "Action",
+                                                  "required": true,
+                                                  "schema": {
+                                                    "type": "object",
+                                                    "required": [
+                                                      "actions",
+                                                      "gas_price",
+                                                      "input_data_ids",
+                                                      "is_promise_yield",
+                                                      "output_data_receivers",
+                                                      "signer_id",
+                                                      "signer_public_key"
+                                                    ],
+                                                    "additionalProperties": false,
+                                                    "properties": [
+                                                      {
+                                                        "name": "actions",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "additionalProperties": true,
+                                                            "refName": "ActionDocument"
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "gas_price",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "input_data_ids",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "string"
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "is_promise_yield",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "output_data_receivers",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "required": [
+                                                              "data_id",
+                                                              "receiver_id"
+                                                            ],
+                                                            "additionalProperties": false,
+                                                            "properties": [
+                                                              {
+                                                                "name": "data_id",
+                                                                "required": true,
+                                                                "schema": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              {
+                                                                "name": "receiver_id",
+                                                                "required": true,
+                                                                "schema": {
+                                                                  "type": "string"
+                                                                }
+                                                              }
+                                                            ],
+                                                            "refName": "OutputDataReceiverDocument"
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "signer_id",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "signer_public_key",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "string"
+                                                        }
+                                                      }
+                                                    ],
+                                                    "refName": "ActionReceiptDocument"
+                                                  }
+                                                }
+                                              ],
+                                              "refName": "ActionReceiptBody"
+                                            },
+                                            {
+                                              "type": "object",
+                                              "required": [
+                                                "Data"
+                                              ],
+                                              "additionalProperties": false,
+                                              "properties": [
+                                                {
+                                                  "name": "Data",
+                                                  "required": true,
+                                                  "schema": {
+                                                    "type": "object",
+                                                    "required": [
+                                                      "data",
+                                                      "data_id",
+                                                      "is_promise_resume"
+                                                    ],
+                                                    "additionalProperties": false,
+                                                    "properties": [
+                                                      {
+                                                        "name": "data",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "data_id",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "is_promise_resume",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "boolean"
+                                                        }
+                                                      }
+                                                    ],
+                                                    "refName": "DataReceiptDocument"
+                                                  }
+                                                }
+                                              ],
+                                              "refName": "DataReceiptBody"
+                                            }
+                                          ],
+                                          "refName": "ReceiptBody"
+                                        }
+                                      },
+                                      {
+                                        "name": "receipt_id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "receiver_id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "ReceiptDocument"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "refName": "OmittedReceiptDocument"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "name": "tx_hash",
+                              "required": false,
+                              "schema": {
+                                "type": "string"
+                              }
+                            }
+                          ],
+                          "refName": "ExecutionWithReceipt"
+                        }
+                      }
+                    },
+                    {
+                      "name": "shard_id",
+                      "required": true,
+                      "schema": {
+                        "type": "integer",
+                        "format": "uint64"
+                      }
+                    },
+                    {
+                      "name": "state_changes",
+                      "required": true,
+                      "schema": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "description": "State change entry returned by neardata for a shard.",
+                          "required": [
+                            "cause",
+                            "change",
+                            "type"
+                          ],
+                          "additionalProperties": false,
+                          "properties": [
+                            {
+                              "name": "cause",
+                              "required": true,
+                              "schema": {
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "required": [
+                                      "tx_hash",
+                                      "type"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "tx_hash",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "type",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "StateChangeCauseTransactionProcessing"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "required": [
+                                      "receipt_hash",
+                                      "type"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "receipt_hash",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "type",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "StateChangeCauseReceiptProcessing"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "required": [
+                                      "receipt_hash",
+                                      "type"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "receipt_hash",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "type",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "StateChangeCauseActionReceiptGasReward"
+                                  }
+                                ],
+                                "refName": "StateChangeCause"
+                              }
+                            },
+                            {
+                              "name": "change",
+                              "required": true,
+                              "schema": {
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "required": [
+                                      "account_id",
+                                      "amount",
+                                      "code_hash",
+                                      "locked",
+                                      "storage_paid_at",
+                                      "storage_usage"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "account_id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "amount",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "code_hash",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "locked",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "storage_paid_at",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "integer",
+                                          "format": "uint64"
+                                        }
+                                      },
+                                      {
+                                        "name": "storage_usage",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "integer",
+                                          "format": "uint64"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "StateChangeValueAccountUpdate"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "required": [
+                                      "access_key",
+                                      "account_id",
+                                      "public_key"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "access_key",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "object",
+                                          "additionalProperties": true
+                                        }
+                                      },
+                                      {
+                                        "name": "account_id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "public_key",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "StateChangeValueAccessKeyUpdate"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "required": [
+                                      "account_id",
+                                      "key_base64",
+                                      "value_base64"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "account_id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "key_base64",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "value_base64",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "StateChangeValueDataUpdate"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "required": [
+                                      "account_id",
+                                      "key_base64"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "account_id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "key_base64",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "StateChangeValueDataDeletion"
+                                  }
+                                ],
+                                "refName": "StateChangeValue"
+                              }
+                            },
+                            {
+                              "name": "type",
+                              "required": true,
+                              "schema": {
+                                "type": "string"
+                              }
+                            }
+                          ],
+                          "refName": "StateChangeItem"
+                        }
+                      }
+                    }
+                  ],
+                  "refName": "ShardDocument"
+                }
+              }
+            }
+          ],
+          "refName": "BlockDocument"
         },
         "status": "200"
       },
@@ -20916,8 +22712,1804 @@
         "mediaType": "application/json",
         "schema": {
           "type": "object",
-          "description": "Full block document as served by neardata, including `block` and `shards`.",
-          "additionalProperties": true
+          "description": "Full block document as served by neardata, including the block envelope and per-shard payloads.",
+          "required": [
+            "block",
+            "shards"
+          ],
+          "additionalProperties": false,
+          "properties": [
+            {
+              "name": "block",
+              "required": true,
+              "schema": {
+                "type": "object",
+                "description": "Block-level payload returned by neardata.",
+                "required": [
+                  "author",
+                  "chunks",
+                  "header"
+                ],
+                "additionalProperties": false,
+                "properties": [
+                  {
+                    "name": "author",
+                    "required": true,
+                    "schema": {
+                      "type": "string",
+                      "description": "Block producer account ID."
+                    }
+                  },
+                  {
+                    "name": "chunks",
+                    "required": true,
+                    "schema": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "description": "Chunk header object as served by neardata.",
+                        "additionalProperties": true,
+                        "properties": [
+                          {
+                            "name": "chunk_hash",
+                            "required": false,
+                            "schema": {
+                              "type": "string"
+                            }
+                          },
+                          {
+                            "name": "gas_limit",
+                            "required": false,
+                            "schema": {
+                              "type": "integer"
+                            }
+                          },
+                          {
+                            "name": "gas_used",
+                            "required": false,
+                            "schema": {
+                              "type": "integer"
+                            }
+                          },
+                          {
+                            "name": "height_created",
+                            "required": false,
+                            "schema": {
+                              "type": "integer",
+                              "format": "uint64"
+                            }
+                          },
+                          {
+                            "name": "height_included",
+                            "required": false,
+                            "schema": {
+                              "type": "integer",
+                              "format": "uint64"
+                            }
+                          },
+                          {
+                            "name": "outcome_root",
+                            "required": false,
+                            "schema": {
+                              "type": "string"
+                            }
+                          },
+                          {
+                            "name": "outgoing_receipts_root",
+                            "required": false,
+                            "schema": {
+                              "type": "string"
+                            }
+                          },
+                          {
+                            "name": "prev_block_hash",
+                            "required": false,
+                            "schema": {
+                              "type": "string"
+                            }
+                          },
+                          {
+                            "name": "shard_id",
+                            "required": false,
+                            "schema": {
+                              "type": "integer",
+                              "format": "uint64"
+                            }
+                          },
+                          {
+                            "name": "tx_root",
+                            "required": false,
+                            "schema": {
+                              "type": "string"
+                            }
+                          }
+                        ],
+                        "refName": "ChunkHeader"
+                      }
+                    }
+                  },
+                  {
+                    "name": "header",
+                    "required": true,
+                    "schema": {
+                      "type": "object",
+                      "description": "Block header object as served by neardata.",
+                      "additionalProperties": true,
+                      "properties": [
+                        {
+                          "name": "chunks_included",
+                          "required": false,
+                          "schema": {
+                            "type": "integer",
+                            "format": "uint64"
+                          }
+                        },
+                        {
+                          "name": "epoch_id",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "name": "gas_price",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "name": "hash",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "name": "height",
+                          "required": false,
+                          "schema": {
+                            "type": "integer",
+                            "format": "uint64"
+                          }
+                        },
+                        {
+                          "name": "next_epoch_id",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "name": "prev_hash",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "name": "prev_height",
+                          "required": false,
+                          "schema": {
+                            "type": "integer",
+                            "format": "uint64"
+                          }
+                        },
+                        {
+                          "name": "timestamp",
+                          "required": false,
+                          "schema": {
+                            "type": "integer"
+                          }
+                        },
+                        {
+                          "name": "timestamp_nanosec",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "name": "total_supply",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        }
+                      ],
+                      "refName": "BlockHeader"
+                    }
+                  }
+                ],
+                "refName": "BlockEnvelope"
+              }
+            },
+            {
+              "name": "shards",
+              "required": true,
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "description": "Per-shard payload returned by neardata for a block.",
+                  "required": [
+                    "chunk",
+                    "receipt_execution_outcomes",
+                    "shard_id",
+                    "state_changes"
+                  ],
+                  "additionalProperties": false,
+                  "properties": [
+                    {
+                      "name": "chunk",
+                      "required": true,
+                      "schema": {
+                        "type": "object",
+                        "description": "Chunk payload returned by neardata for a single shard in a selected block.",
+                        "required": [
+                          "author",
+                          "header",
+                          "receipts",
+                          "transactions"
+                        ],
+                        "additionalProperties": false,
+                        "properties": [
+                          {
+                            "name": "author",
+                            "required": true,
+                            "schema": {
+                              "type": "string",
+                              "description": "Chunk producer account ID."
+                            }
+                          },
+                          {
+                            "name": "header",
+                            "required": true,
+                            "schema": {
+                              "type": "object",
+                              "description": "Chunk header object as served by neardata.",
+                              "additionalProperties": true,
+                              "properties": [
+                                {
+                                  "name": "chunk_hash",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "string"
+                                  }
+                                },
+                                {
+                                  "name": "gas_limit",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "integer"
+                                  }
+                                },
+                                {
+                                  "name": "gas_used",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "integer"
+                                  }
+                                },
+                                {
+                                  "name": "height_created",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "integer",
+                                    "format": "uint64"
+                                  }
+                                },
+                                {
+                                  "name": "height_included",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "integer",
+                                    "format": "uint64"
+                                  }
+                                },
+                                {
+                                  "name": "outcome_root",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "string"
+                                  }
+                                },
+                                {
+                                  "name": "outgoing_receipts_root",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "string"
+                                  }
+                                },
+                                {
+                                  "name": "prev_block_hash",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "string"
+                                  }
+                                },
+                                {
+                                  "name": "shard_id",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "integer",
+                                    "format": "uint64"
+                                  }
+                                },
+                                {
+                                  "name": "tx_root",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "string"
+                                  }
+                                }
+                              ],
+                              "refName": "ChunkHeader"
+                            }
+                          },
+                          {
+                            "name": "receipts",
+                            "required": true,
+                            "schema": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "description": "Receipt object as served by neardata inside a chunk payload.",
+                                "required": [
+                                  "predecessor_id",
+                                  "priority",
+                                  "receipt",
+                                  "receipt_id",
+                                  "receiver_id"
+                                ],
+                                "additionalProperties": false,
+                                "properties": [
+                                  {
+                                    "name": "predecessor_id",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  {
+                                    "name": "priority",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "integer",
+                                      "format": "uint64"
+                                    }
+                                  },
+                                  {
+                                    "name": "receipt",
+                                    "required": true,
+                                    "schema": {
+                                      "oneOf": [
+                                        {
+                                          "type": "object",
+                                          "required": [
+                                            "Action"
+                                          ],
+                                          "additionalProperties": false,
+                                          "properties": [
+                                            {
+                                              "name": "Action",
+                                              "required": true,
+                                              "schema": {
+                                                "type": "object",
+                                                "required": [
+                                                  "actions",
+                                                  "gas_price",
+                                                  "input_data_ids",
+                                                  "is_promise_yield",
+                                                  "output_data_receivers",
+                                                  "signer_id",
+                                                  "signer_public_key"
+                                                ],
+                                                "additionalProperties": false,
+                                                "properties": [
+                                                  {
+                                                    "name": "actions",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "object",
+                                                        "additionalProperties": true,
+                                                        "refName": "ActionDocument"
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "gas_price",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "input_data_ids",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "is_promise_yield",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "output_data_receivers",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "object",
+                                                        "required": [
+                                                          "data_id",
+                                                          "receiver_id"
+                                                        ],
+                                                        "additionalProperties": false,
+                                                        "properties": [
+                                                          {
+                                                            "name": "data_id",
+                                                            "required": true,
+                                                            "schema": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          {
+                                                            "name": "receiver_id",
+                                                            "required": true,
+                                                            "schema": {
+                                                              "type": "string"
+                                                            }
+                                                          }
+                                                        ],
+                                                        "refName": "OutputDataReceiverDocument"
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "signer_id",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "signer_public_key",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                ],
+                                                "refName": "ActionReceiptDocument"
+                                              }
+                                            }
+                                          ],
+                                          "refName": "ActionReceiptBody"
+                                        },
+                                        {
+                                          "type": "object",
+                                          "required": [
+                                            "Data"
+                                          ],
+                                          "additionalProperties": false,
+                                          "properties": [
+                                            {
+                                              "name": "Data",
+                                              "required": true,
+                                              "schema": {
+                                                "type": "object",
+                                                "required": [
+                                                  "data",
+                                                  "data_id",
+                                                  "is_promise_resume"
+                                                ],
+                                                "additionalProperties": false,
+                                                "properties": [
+                                                  {
+                                                    "name": "data",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "data_id",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "is_promise_resume",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "boolean"
+                                                    }
+                                                  }
+                                                ],
+                                                "refName": "DataReceiptDocument"
+                                              }
+                                            }
+                                          ],
+                                          "refName": "DataReceiptBody"
+                                        }
+                                      ],
+                                      "refName": "ReceiptBody"
+                                    }
+                                  },
+                                  {
+                                    "name": "receipt_id",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  {
+                                    "name": "receiver_id",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "string"
+                                    }
+                                  }
+                                ],
+                                "refName": "ReceiptDocument"
+                              }
+                            }
+                          },
+                          {
+                            "name": "transactions",
+                            "required": true,
+                            "schema": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "description": "Transaction entry returned inside a neardata chunk.",
+                                "required": [
+                                  "outcome",
+                                  "transaction"
+                                ],
+                                "additionalProperties": false,
+                                "properties": [
+                                  {
+                                    "name": "outcome",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "object",
+                                      "description": "Execution result paired with an optional receipt object.",
+                                      "required": [
+                                        "execution_outcome",
+                                        "receipt"
+                                      ],
+                                      "additionalProperties": false,
+                                      "properties": [
+                                        {
+                                          "name": "execution_outcome",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "object",
+                                            "required": [
+                                              "block_hash",
+                                              "id",
+                                              "outcome",
+                                              "proof"
+                                            ],
+                                            "additionalProperties": false,
+                                            "properties": [
+                                              {
+                                                "name": "block_hash",
+                                                "required": true,
+                                                "schema": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              {
+                                                "name": "id",
+                                                "required": true,
+                                                "schema": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              {
+                                                "name": "outcome",
+                                                "required": true,
+                                                "schema": {
+                                                  "type": "object",
+                                                  "required": [
+                                                    "executor_id",
+                                                    "gas_burnt",
+                                                    "logs",
+                                                    "metadata",
+                                                    "receipt_ids",
+                                                    "status",
+                                                    "tokens_burnt"
+                                                  ],
+                                                  "additionalProperties": false,
+                                                  "properties": [
+                                                    {
+                                                      "name": "executor_id",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "gas_burnt",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "integer",
+                                                        "format": "uint64"
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "logs",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "metadata",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "object",
+                                                        "additionalProperties": true
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "receipt_ids",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "status",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "oneOf": [
+                                                          {
+                                                            "type": "object",
+                                                            "required": [
+                                                              "SuccessReceiptId"
+                                                            ],
+                                                            "additionalProperties": false,
+                                                            "properties": [
+                                                              {
+                                                                "name": "SuccessReceiptId",
+                                                                "required": true,
+                                                                "schema": {
+                                                                  "type": "string"
+                                                                }
+                                                              }
+                                                            ],
+                                                            "refName": "ExecutionOutcomeStatusSuccessReceiptId"
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "required": [
+                                                              "SuccessValue"
+                                                            ],
+                                                            "additionalProperties": false,
+                                                            "properties": [
+                                                              {
+                                                                "name": "SuccessValue",
+                                                                "required": true,
+                                                                "schema": {
+                                                                  "type": "string"
+                                                                }
+                                                              }
+                                                            ],
+                                                            "refName": "ExecutionOutcomeStatusSuccessValue"
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "required": [
+                                                              "Failure"
+                                                            ],
+                                                            "additionalProperties": false,
+                                                            "properties": [
+                                                              {
+                                                                "name": "Failure",
+                                                                "required": true,
+                                                                "schema": {
+                                                                  "type": "object",
+                                                                  "additionalProperties": true
+                                                                }
+                                                              }
+                                                            ],
+                                                            "refName": "ExecutionOutcomeStatusFailure"
+                                                          }
+                                                        ],
+                                                        "refName": "ExecutionOutcomeStatus"
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "tokens_burnt",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  ],
+                                                  "refName": "ExecutionOutcomeSummary"
+                                                }
+                                              },
+                                              {
+                                                "name": "proof",
+                                                "required": true,
+                                                "schema": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "object",
+                                                    "additionalProperties": true,
+                                                    "refName": "ExecutionProofItem"
+                                                  }
+                                                }
+                                              }
+                                            ],
+                                            "refName": "ExecutionOutcomeDocument"
+                                          }
+                                        },
+                                        {
+                                          "name": "receipt",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "object",
+                                            "description": "Receipt payload when neardata includes it for this entry.",
+                                            "oneOf": [
+                                              {
+                                                "type": "object",
+                                                "description": "Receipt object as served by neardata inside a chunk payload.",
+                                                "required": [
+                                                  "predecessor_id",
+                                                  "priority",
+                                                  "receipt",
+                                                  "receipt_id",
+                                                  "receiver_id"
+                                                ],
+                                                "additionalProperties": false,
+                                                "properties": [
+                                                  {
+                                                    "name": "predecessor_id",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "priority",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "integer",
+                                                      "format": "uint64"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "receipt",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "oneOf": [
+                                                        {
+                                                          "type": "object",
+                                                          "required": [
+                                                            "Action"
+                                                          ],
+                                                          "additionalProperties": false,
+                                                          "properties": [
+                                                            {
+                                                              "name": "Action",
+                                                              "required": true,
+                                                              "schema": {
+                                                                "type": "object",
+                                                                "required": [
+                                                                  "actions",
+                                                                  "gas_price",
+                                                                  "input_data_ids",
+                                                                  "is_promise_yield",
+                                                                  "output_data_receivers",
+                                                                  "signer_id",
+                                                                  "signer_public_key"
+                                                                ],
+                                                                "additionalProperties": false,
+                                                                "properties": [
+                                                                  {
+                                                                    "name": "actions",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "array",
+                                                                      "items": {
+                                                                        "type": "object",
+                                                                        "additionalProperties": true,
+                                                                        "refName": "ActionDocument"
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "gas_price",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "input_data_ids",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "array",
+                                                                      "items": {
+                                                                        "type": "string"
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "is_promise_yield",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "boolean"
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "output_data_receivers",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "array",
+                                                                      "items": {
+                                                                        "type": "object",
+                                                                        "required": [
+                                                                          "data_id",
+                                                                          "receiver_id"
+                                                                        ],
+                                                                        "additionalProperties": false,
+                                                                        "properties": [
+                                                                          {
+                                                                            "name": "data_id",
+                                                                            "required": true,
+                                                                            "schema": {
+                                                                              "type": "string"
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "name": "receiver_id",
+                                                                            "required": true,
+                                                                            "schema": {
+                                                                              "type": "string"
+                                                                            }
+                                                                          }
+                                                                        ],
+                                                                        "refName": "OutputDataReceiverDocument"
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "signer_id",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "signer_public_key",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  }
+                                                                ],
+                                                                "refName": "ActionReceiptDocument"
+                                                              }
+                                                            }
+                                                          ],
+                                                          "refName": "ActionReceiptBody"
+                                                        },
+                                                        {
+                                                          "type": "object",
+                                                          "required": [
+                                                            "Data"
+                                                          ],
+                                                          "additionalProperties": false,
+                                                          "properties": [
+                                                            {
+                                                              "name": "Data",
+                                                              "required": true,
+                                                              "schema": {
+                                                                "type": "object",
+                                                                "required": [
+                                                                  "data",
+                                                                  "data_id",
+                                                                  "is_promise_resume"
+                                                                ],
+                                                                "additionalProperties": false,
+                                                                "properties": [
+                                                                  {
+                                                                    "name": "data",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "data_id",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "is_promise_resume",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "boolean"
+                                                                    }
+                                                                  }
+                                                                ],
+                                                                "refName": "DataReceiptDocument"
+                                                              }
+                                                            }
+                                                          ],
+                                                          "refName": "DataReceiptBody"
+                                                        }
+                                                      ],
+                                                      "refName": "ReceiptBody"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "receipt_id",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "receiver_id",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                ],
+                                                "refName": "ReceiptDocument"
+                                              },
+                                              {
+                                                "type": "object",
+                                                "additionalProperties": false,
+                                                "refName": "OmittedReceiptDocument"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "name": "tx_hash",
+                                          "required": false,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      ],
+                                      "refName": "ExecutionWithReceipt"
+                                    }
+                                  },
+                                  {
+                                    "name": "transaction",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "object",
+                                      "required": [
+                                        "actions",
+                                        "hash",
+                                        "nonce",
+                                        "priority_fee",
+                                        "public_key",
+                                        "receiver_id",
+                                        "signature",
+                                        "signer_id"
+                                      ],
+                                      "additionalProperties": false,
+                                      "properties": [
+                                        {
+                                          "name": "actions",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "additionalProperties": true,
+                                              "refName": "ActionDocument"
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "name": "hash",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        {
+                                          "name": "nonce",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "integer",
+                                            "format": "uint64"
+                                          }
+                                        },
+                                        {
+                                          "name": "priority_fee",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "integer",
+                                            "format": "uint64"
+                                          }
+                                        },
+                                        {
+                                          "name": "public_key",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        {
+                                          "name": "receiver_id",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        {
+                                          "name": "signature",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        {
+                                          "name": "signer_id",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      ],
+                                      "refName": "SignedTransactionDocument"
+                                    }
+                                  }
+                                ],
+                                "refName": "ChunkTransactionWrapper"
+                              }
+                            }
+                          }
+                        ],
+                        "refName": "ChunkDocument"
+                      }
+                    },
+                    {
+                      "name": "receipt_execution_outcomes",
+                      "required": true,
+                      "schema": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "description": "Execution result paired with an optional receipt object.",
+                          "required": [
+                            "execution_outcome",
+                            "receipt"
+                          ],
+                          "additionalProperties": false,
+                          "properties": [
+                            {
+                              "name": "execution_outcome",
+                              "required": true,
+                              "schema": {
+                                "type": "object",
+                                "required": [
+                                  "block_hash",
+                                  "id",
+                                  "outcome",
+                                  "proof"
+                                ],
+                                "additionalProperties": false,
+                                "properties": [
+                                  {
+                                    "name": "block_hash",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  {
+                                    "name": "id",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  {
+                                    "name": "outcome",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "object",
+                                      "required": [
+                                        "executor_id",
+                                        "gas_burnt",
+                                        "logs",
+                                        "metadata",
+                                        "receipt_ids",
+                                        "status",
+                                        "tokens_burnt"
+                                      ],
+                                      "additionalProperties": false,
+                                      "properties": [
+                                        {
+                                          "name": "executor_id",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        {
+                                          "name": "gas_burnt",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "integer",
+                                            "format": "uint64"
+                                          }
+                                        },
+                                        {
+                                          "name": "logs",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "name": "metadata",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "object",
+                                            "additionalProperties": true
+                                          }
+                                        },
+                                        {
+                                          "name": "receipt_ids",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "name": "status",
+                                          "required": true,
+                                          "schema": {
+                                            "oneOf": [
+                                              {
+                                                "type": "object",
+                                                "required": [
+                                                  "SuccessReceiptId"
+                                                ],
+                                                "additionalProperties": false,
+                                                "properties": [
+                                                  {
+                                                    "name": "SuccessReceiptId",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                ],
+                                                "refName": "ExecutionOutcomeStatusSuccessReceiptId"
+                                              },
+                                              {
+                                                "type": "object",
+                                                "required": [
+                                                  "SuccessValue"
+                                                ],
+                                                "additionalProperties": false,
+                                                "properties": [
+                                                  {
+                                                    "name": "SuccessValue",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                ],
+                                                "refName": "ExecutionOutcomeStatusSuccessValue"
+                                              },
+                                              {
+                                                "type": "object",
+                                                "required": [
+                                                  "Failure"
+                                                ],
+                                                "additionalProperties": false,
+                                                "properties": [
+                                                  {
+                                                    "name": "Failure",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "object",
+                                                      "additionalProperties": true
+                                                    }
+                                                  }
+                                                ],
+                                                "refName": "ExecutionOutcomeStatusFailure"
+                                              }
+                                            ],
+                                            "refName": "ExecutionOutcomeStatus"
+                                          }
+                                        },
+                                        {
+                                          "name": "tokens_burnt",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      ],
+                                      "refName": "ExecutionOutcomeSummary"
+                                    }
+                                  },
+                                  {
+                                    "name": "proof",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "additionalProperties": true,
+                                        "refName": "ExecutionProofItem"
+                                      }
+                                    }
+                                  }
+                                ],
+                                "refName": "ExecutionOutcomeDocument"
+                              }
+                            },
+                            {
+                              "name": "receipt",
+                              "required": true,
+                              "schema": {
+                                "type": "object",
+                                "description": "Receipt payload when neardata includes it for this entry.",
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "description": "Receipt object as served by neardata inside a chunk payload.",
+                                    "required": [
+                                      "predecessor_id",
+                                      "priority",
+                                      "receipt",
+                                      "receipt_id",
+                                      "receiver_id"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "predecessor_id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "priority",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "integer",
+                                          "format": "uint64"
+                                        }
+                                      },
+                                      {
+                                        "name": "receipt",
+                                        "required": true,
+                                        "schema": {
+                                          "oneOf": [
+                                            {
+                                              "type": "object",
+                                              "required": [
+                                                "Action"
+                                              ],
+                                              "additionalProperties": false,
+                                              "properties": [
+                                                {
+                                                  "name": "Action",
+                                                  "required": true,
+                                                  "schema": {
+                                                    "type": "object",
+                                                    "required": [
+                                                      "actions",
+                                                      "gas_price",
+                                                      "input_data_ids",
+                                                      "is_promise_yield",
+                                                      "output_data_receivers",
+                                                      "signer_id",
+                                                      "signer_public_key"
+                                                    ],
+                                                    "additionalProperties": false,
+                                                    "properties": [
+                                                      {
+                                                        "name": "actions",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "additionalProperties": true,
+                                                            "refName": "ActionDocument"
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "gas_price",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "input_data_ids",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "string"
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "is_promise_yield",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "output_data_receivers",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "required": [
+                                                              "data_id",
+                                                              "receiver_id"
+                                                            ],
+                                                            "additionalProperties": false,
+                                                            "properties": [
+                                                              {
+                                                                "name": "data_id",
+                                                                "required": true,
+                                                                "schema": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              {
+                                                                "name": "receiver_id",
+                                                                "required": true,
+                                                                "schema": {
+                                                                  "type": "string"
+                                                                }
+                                                              }
+                                                            ],
+                                                            "refName": "OutputDataReceiverDocument"
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "signer_id",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "signer_public_key",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "string"
+                                                        }
+                                                      }
+                                                    ],
+                                                    "refName": "ActionReceiptDocument"
+                                                  }
+                                                }
+                                              ],
+                                              "refName": "ActionReceiptBody"
+                                            },
+                                            {
+                                              "type": "object",
+                                              "required": [
+                                                "Data"
+                                              ],
+                                              "additionalProperties": false,
+                                              "properties": [
+                                                {
+                                                  "name": "Data",
+                                                  "required": true,
+                                                  "schema": {
+                                                    "type": "object",
+                                                    "required": [
+                                                      "data",
+                                                      "data_id",
+                                                      "is_promise_resume"
+                                                    ],
+                                                    "additionalProperties": false,
+                                                    "properties": [
+                                                      {
+                                                        "name": "data",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "data_id",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "is_promise_resume",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "boolean"
+                                                        }
+                                                      }
+                                                    ],
+                                                    "refName": "DataReceiptDocument"
+                                                  }
+                                                }
+                                              ],
+                                              "refName": "DataReceiptBody"
+                                            }
+                                          ],
+                                          "refName": "ReceiptBody"
+                                        }
+                                      },
+                                      {
+                                        "name": "receipt_id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "receiver_id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "ReceiptDocument"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "refName": "OmittedReceiptDocument"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "name": "tx_hash",
+                              "required": false,
+                              "schema": {
+                                "type": "string"
+                              }
+                            }
+                          ],
+                          "refName": "ExecutionWithReceipt"
+                        }
+                      }
+                    },
+                    {
+                      "name": "shard_id",
+                      "required": true,
+                      "schema": {
+                        "type": "integer",
+                        "format": "uint64"
+                      }
+                    },
+                    {
+                      "name": "state_changes",
+                      "required": true,
+                      "schema": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "description": "State change entry returned by neardata for a shard.",
+                          "required": [
+                            "cause",
+                            "change",
+                            "type"
+                          ],
+                          "additionalProperties": false,
+                          "properties": [
+                            {
+                              "name": "cause",
+                              "required": true,
+                              "schema": {
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "required": [
+                                      "tx_hash",
+                                      "type"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "tx_hash",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "type",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "StateChangeCauseTransactionProcessing"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "required": [
+                                      "receipt_hash",
+                                      "type"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "receipt_hash",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "type",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "StateChangeCauseReceiptProcessing"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "required": [
+                                      "receipt_hash",
+                                      "type"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "receipt_hash",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "type",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "StateChangeCauseActionReceiptGasReward"
+                                  }
+                                ],
+                                "refName": "StateChangeCause"
+                              }
+                            },
+                            {
+                              "name": "change",
+                              "required": true,
+                              "schema": {
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "required": [
+                                      "account_id",
+                                      "amount",
+                                      "code_hash",
+                                      "locked",
+                                      "storage_paid_at",
+                                      "storage_usage"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "account_id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "amount",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "code_hash",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "locked",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "storage_paid_at",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "integer",
+                                          "format": "uint64"
+                                        }
+                                      },
+                                      {
+                                        "name": "storage_usage",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "integer",
+                                          "format": "uint64"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "StateChangeValueAccountUpdate"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "required": [
+                                      "access_key",
+                                      "account_id",
+                                      "public_key"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "access_key",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "object",
+                                          "additionalProperties": true
+                                        }
+                                      },
+                                      {
+                                        "name": "account_id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "public_key",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "StateChangeValueAccessKeyUpdate"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "required": [
+                                      "account_id",
+                                      "key_base64",
+                                      "value_base64"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "account_id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "key_base64",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "value_base64",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "StateChangeValueDataUpdate"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "required": [
+                                      "account_id",
+                                      "key_base64"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "account_id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "key_base64",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "StateChangeValueDataDeletion"
+                                  }
+                                ],
+                                "refName": "StateChangeValue"
+                              }
+                            },
+                            {
+                              "name": "type",
+                              "required": true,
+                              "schema": {
+                                "type": "string"
+                              }
+                            }
+                          ],
+                          "refName": "StateChangeItem"
+                        }
+                      }
+                    }
+                  ],
+                  "refName": "ShardDocument"
+                }
+              }
+            }
+          ],
+          "refName": "BlockDocument"
         },
         "status": "200"
       },
@@ -21112,8 +24704,204 @@
         "mediaType": "application/json",
         "schema": {
           "type": "object",
-          "description": "Block-level object returned by `/headers`, corresponding to the full response's `block` field.",
-          "additionalProperties": true
+          "description": "Block-level payload returned by neardata.",
+          "required": [
+            "author",
+            "chunks",
+            "header"
+          ],
+          "additionalProperties": false,
+          "properties": [
+            {
+              "name": "author",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Block producer account ID."
+              }
+            },
+            {
+              "name": "chunks",
+              "required": true,
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "description": "Chunk header object as served by neardata.",
+                  "additionalProperties": true,
+                  "properties": [
+                    {
+                      "name": "chunk_hash",
+                      "required": false,
+                      "schema": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "name": "gas_limit",
+                      "required": false,
+                      "schema": {
+                        "type": "integer"
+                      }
+                    },
+                    {
+                      "name": "gas_used",
+                      "required": false,
+                      "schema": {
+                        "type": "integer"
+                      }
+                    },
+                    {
+                      "name": "height_created",
+                      "required": false,
+                      "schema": {
+                        "type": "integer",
+                        "format": "uint64"
+                      }
+                    },
+                    {
+                      "name": "height_included",
+                      "required": false,
+                      "schema": {
+                        "type": "integer",
+                        "format": "uint64"
+                      }
+                    },
+                    {
+                      "name": "outcome_root",
+                      "required": false,
+                      "schema": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "name": "outgoing_receipts_root",
+                      "required": false,
+                      "schema": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "name": "prev_block_hash",
+                      "required": false,
+                      "schema": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "name": "shard_id",
+                      "required": false,
+                      "schema": {
+                        "type": "integer",
+                        "format": "uint64"
+                      }
+                    },
+                    {
+                      "name": "tx_root",
+                      "required": false,
+                      "schema": {
+                        "type": "string"
+                      }
+                    }
+                  ],
+                  "refName": "ChunkHeader"
+                }
+              }
+            },
+            {
+              "name": "header",
+              "required": true,
+              "schema": {
+                "type": "object",
+                "description": "Block header object as served by neardata.",
+                "additionalProperties": true,
+                "properties": [
+                  {
+                    "name": "chunks_included",
+                    "required": false,
+                    "schema": {
+                      "type": "integer",
+                      "format": "uint64"
+                    }
+                  },
+                  {
+                    "name": "epoch_id",
+                    "required": false,
+                    "schema": {
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "name": "gas_price",
+                    "required": false,
+                    "schema": {
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "name": "hash",
+                    "required": false,
+                    "schema": {
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "name": "height",
+                    "required": false,
+                    "schema": {
+                      "type": "integer",
+                      "format": "uint64"
+                    }
+                  },
+                  {
+                    "name": "next_epoch_id",
+                    "required": false,
+                    "schema": {
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "name": "prev_hash",
+                    "required": false,
+                    "schema": {
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "name": "prev_height",
+                    "required": false,
+                    "schema": {
+                      "type": "integer",
+                      "format": "uint64"
+                    }
+                  },
+                  {
+                    "name": "timestamp",
+                    "required": false,
+                    "schema": {
+                      "type": "integer"
+                    }
+                  },
+                  {
+                    "name": "timestamp_nanosec",
+                    "required": false,
+                    "schema": {
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "name": "total_supply",
+                    "required": false,
+                    "schema": {
+                      "type": "string"
+                    }
+                  }
+                ],
+                "refName": "BlockHeader"
+              }
+            }
+          ],
+          "refName": "BlockEnvelope"
         },
         "status": "200"
       },
@@ -21333,8 +25121,856 @@
         "mediaType": "application/json",
         "schema": {
           "type": "object",
-          "description": "Chunk object for the requested shard ID.",
-          "additionalProperties": true
+          "description": "Chunk payload returned by neardata for a single shard in a selected block.",
+          "required": [
+            "author",
+            "header",
+            "receipts",
+            "transactions"
+          ],
+          "additionalProperties": false,
+          "properties": [
+            {
+              "name": "author",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Chunk producer account ID."
+              }
+            },
+            {
+              "name": "header",
+              "required": true,
+              "schema": {
+                "type": "object",
+                "description": "Chunk header object as served by neardata.",
+                "additionalProperties": true,
+                "properties": [
+                  {
+                    "name": "chunk_hash",
+                    "required": false,
+                    "schema": {
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "name": "gas_limit",
+                    "required": false,
+                    "schema": {
+                      "type": "integer"
+                    }
+                  },
+                  {
+                    "name": "gas_used",
+                    "required": false,
+                    "schema": {
+                      "type": "integer"
+                    }
+                  },
+                  {
+                    "name": "height_created",
+                    "required": false,
+                    "schema": {
+                      "type": "integer",
+                      "format": "uint64"
+                    }
+                  },
+                  {
+                    "name": "height_included",
+                    "required": false,
+                    "schema": {
+                      "type": "integer",
+                      "format": "uint64"
+                    }
+                  },
+                  {
+                    "name": "outcome_root",
+                    "required": false,
+                    "schema": {
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "name": "outgoing_receipts_root",
+                    "required": false,
+                    "schema": {
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "name": "prev_block_hash",
+                    "required": false,
+                    "schema": {
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "name": "shard_id",
+                    "required": false,
+                    "schema": {
+                      "type": "integer",
+                      "format": "uint64"
+                    }
+                  },
+                  {
+                    "name": "tx_root",
+                    "required": false,
+                    "schema": {
+                      "type": "string"
+                    }
+                  }
+                ],
+                "refName": "ChunkHeader"
+              }
+            },
+            {
+              "name": "receipts",
+              "required": true,
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "description": "Receipt object as served by neardata inside a chunk payload.",
+                  "required": [
+                    "predecessor_id",
+                    "priority",
+                    "receipt",
+                    "receipt_id",
+                    "receiver_id"
+                  ],
+                  "additionalProperties": false,
+                  "properties": [
+                    {
+                      "name": "predecessor_id",
+                      "required": true,
+                      "schema": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "name": "priority",
+                      "required": true,
+                      "schema": {
+                        "type": "integer",
+                        "format": "uint64"
+                      }
+                    },
+                    {
+                      "name": "receipt",
+                      "required": true,
+                      "schema": {
+                        "oneOf": [
+                          {
+                            "type": "object",
+                            "required": [
+                              "Action"
+                            ],
+                            "additionalProperties": false,
+                            "properties": [
+                              {
+                                "name": "Action",
+                                "required": true,
+                                "schema": {
+                                  "type": "object",
+                                  "required": [
+                                    "actions",
+                                    "gas_price",
+                                    "input_data_ids",
+                                    "is_promise_yield",
+                                    "output_data_receivers",
+                                    "signer_id",
+                                    "signer_public_key"
+                                  ],
+                                  "additionalProperties": false,
+                                  "properties": [
+                                    {
+                                      "name": "actions",
+                                      "required": true,
+                                      "schema": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "additionalProperties": true,
+                                          "refName": "ActionDocument"
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "name": "gas_price",
+                                      "required": true,
+                                      "schema": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    {
+                                      "name": "input_data_ids",
+                                      "required": true,
+                                      "schema": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "name": "is_promise_yield",
+                                      "required": true,
+                                      "schema": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    {
+                                      "name": "output_data_receivers",
+                                      "required": true,
+                                      "schema": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "required": [
+                                            "data_id",
+                                            "receiver_id"
+                                          ],
+                                          "additionalProperties": false,
+                                          "properties": [
+                                            {
+                                              "name": "data_id",
+                                              "required": true,
+                                              "schema": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            {
+                                              "name": "receiver_id",
+                                              "required": true,
+                                              "schema": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          ],
+                                          "refName": "OutputDataReceiverDocument"
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "name": "signer_id",
+                                      "required": true,
+                                      "schema": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    {
+                                      "name": "signer_public_key",
+                                      "required": true,
+                                      "schema": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  ],
+                                  "refName": "ActionReceiptDocument"
+                                }
+                              }
+                            ],
+                            "refName": "ActionReceiptBody"
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "Data"
+                            ],
+                            "additionalProperties": false,
+                            "properties": [
+                              {
+                                "name": "Data",
+                                "required": true,
+                                "schema": {
+                                  "type": "object",
+                                  "required": [
+                                    "data",
+                                    "data_id",
+                                    "is_promise_resume"
+                                  ],
+                                  "additionalProperties": false,
+                                  "properties": [
+                                    {
+                                      "name": "data",
+                                      "required": true,
+                                      "schema": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    {
+                                      "name": "data_id",
+                                      "required": true,
+                                      "schema": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    {
+                                      "name": "is_promise_resume",
+                                      "required": true,
+                                      "schema": {
+                                        "type": "boolean"
+                                      }
+                                    }
+                                  ],
+                                  "refName": "DataReceiptDocument"
+                                }
+                              }
+                            ],
+                            "refName": "DataReceiptBody"
+                          }
+                        ],
+                        "refName": "ReceiptBody"
+                      }
+                    },
+                    {
+                      "name": "receipt_id",
+                      "required": true,
+                      "schema": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "name": "receiver_id",
+                      "required": true,
+                      "schema": {
+                        "type": "string"
+                      }
+                    }
+                  ],
+                  "refName": "ReceiptDocument"
+                }
+              }
+            },
+            {
+              "name": "transactions",
+              "required": true,
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "description": "Transaction entry returned inside a neardata chunk.",
+                  "required": [
+                    "outcome",
+                    "transaction"
+                  ],
+                  "additionalProperties": false,
+                  "properties": [
+                    {
+                      "name": "outcome",
+                      "required": true,
+                      "schema": {
+                        "type": "object",
+                        "description": "Execution result paired with an optional receipt object.",
+                        "required": [
+                          "execution_outcome",
+                          "receipt"
+                        ],
+                        "additionalProperties": false,
+                        "properties": [
+                          {
+                            "name": "execution_outcome",
+                            "required": true,
+                            "schema": {
+                              "type": "object",
+                              "required": [
+                                "block_hash",
+                                "id",
+                                "outcome",
+                                "proof"
+                              ],
+                              "additionalProperties": false,
+                              "properties": [
+                                {
+                                  "name": "block_hash",
+                                  "required": true,
+                                  "schema": {
+                                    "type": "string"
+                                  }
+                                },
+                                {
+                                  "name": "id",
+                                  "required": true,
+                                  "schema": {
+                                    "type": "string"
+                                  }
+                                },
+                                {
+                                  "name": "outcome",
+                                  "required": true,
+                                  "schema": {
+                                    "type": "object",
+                                    "required": [
+                                      "executor_id",
+                                      "gas_burnt",
+                                      "logs",
+                                      "metadata",
+                                      "receipt_ids",
+                                      "status",
+                                      "tokens_burnt"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "executor_id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "gas_burnt",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "integer",
+                                          "format": "uint64"
+                                        }
+                                      },
+                                      {
+                                        "name": "logs",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "name": "metadata",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "object",
+                                          "additionalProperties": true
+                                        }
+                                      },
+                                      {
+                                        "name": "receipt_ids",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "name": "status",
+                                        "required": true,
+                                        "schema": {
+                                          "oneOf": [
+                                            {
+                                              "type": "object",
+                                              "required": [
+                                                "SuccessReceiptId"
+                                              ],
+                                              "additionalProperties": false,
+                                              "properties": [
+                                                {
+                                                  "name": "SuccessReceiptId",
+                                                  "required": true,
+                                                  "schema": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              ],
+                                              "refName": "ExecutionOutcomeStatusSuccessReceiptId"
+                                            },
+                                            {
+                                              "type": "object",
+                                              "required": [
+                                                "SuccessValue"
+                                              ],
+                                              "additionalProperties": false,
+                                              "properties": [
+                                                {
+                                                  "name": "SuccessValue",
+                                                  "required": true,
+                                                  "schema": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              ],
+                                              "refName": "ExecutionOutcomeStatusSuccessValue"
+                                            },
+                                            {
+                                              "type": "object",
+                                              "required": [
+                                                "Failure"
+                                              ],
+                                              "additionalProperties": false,
+                                              "properties": [
+                                                {
+                                                  "name": "Failure",
+                                                  "required": true,
+                                                  "schema": {
+                                                    "type": "object",
+                                                    "additionalProperties": true
+                                                  }
+                                                }
+                                              ],
+                                              "refName": "ExecutionOutcomeStatusFailure"
+                                            }
+                                          ],
+                                          "refName": "ExecutionOutcomeStatus"
+                                        }
+                                      },
+                                      {
+                                        "name": "tokens_burnt",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "ExecutionOutcomeSummary"
+                                  }
+                                },
+                                {
+                                  "name": "proof",
+                                  "required": true,
+                                  "schema": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "additionalProperties": true,
+                                      "refName": "ExecutionProofItem"
+                                    }
+                                  }
+                                }
+                              ],
+                              "refName": "ExecutionOutcomeDocument"
+                            }
+                          },
+                          {
+                            "name": "receipt",
+                            "required": true,
+                            "schema": {
+                              "type": "object",
+                              "description": "Receipt payload when neardata includes it for this entry.",
+                              "oneOf": [
+                                {
+                                  "type": "object",
+                                  "description": "Receipt object as served by neardata inside a chunk payload.",
+                                  "required": [
+                                    "predecessor_id",
+                                    "priority",
+                                    "receipt",
+                                    "receipt_id",
+                                    "receiver_id"
+                                  ],
+                                  "additionalProperties": false,
+                                  "properties": [
+                                    {
+                                      "name": "predecessor_id",
+                                      "required": true,
+                                      "schema": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    {
+                                      "name": "priority",
+                                      "required": true,
+                                      "schema": {
+                                        "type": "integer",
+                                        "format": "uint64"
+                                      }
+                                    },
+                                    {
+                                      "name": "receipt",
+                                      "required": true,
+                                      "schema": {
+                                        "oneOf": [
+                                          {
+                                            "type": "object",
+                                            "required": [
+                                              "Action"
+                                            ],
+                                            "additionalProperties": false,
+                                            "properties": [
+                                              {
+                                                "name": "Action",
+                                                "required": true,
+                                                "schema": {
+                                                  "type": "object",
+                                                  "required": [
+                                                    "actions",
+                                                    "gas_price",
+                                                    "input_data_ids",
+                                                    "is_promise_yield",
+                                                    "output_data_receivers",
+                                                    "signer_id",
+                                                    "signer_public_key"
+                                                  ],
+                                                  "additionalProperties": false,
+                                                  "properties": [
+                                                    {
+                                                      "name": "actions",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "object",
+                                                          "additionalProperties": true,
+                                                          "refName": "ActionDocument"
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "gas_price",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "input_data_ids",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "is_promise_yield",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "output_data_receivers",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "object",
+                                                          "required": [
+                                                            "data_id",
+                                                            "receiver_id"
+                                                          ],
+                                                          "additionalProperties": false,
+                                                          "properties": [
+                                                            {
+                                                              "name": "data_id",
+                                                              "required": true,
+                                                              "schema": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            {
+                                                              "name": "receiver_id",
+                                                              "required": true,
+                                                              "schema": {
+                                                                "type": "string"
+                                                              }
+                                                            }
+                                                          ],
+                                                          "refName": "OutputDataReceiverDocument"
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "signer_id",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "signer_public_key",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  ],
+                                                  "refName": "ActionReceiptDocument"
+                                                }
+                                              }
+                                            ],
+                                            "refName": "ActionReceiptBody"
+                                          },
+                                          {
+                                            "type": "object",
+                                            "required": [
+                                              "Data"
+                                            ],
+                                            "additionalProperties": false,
+                                            "properties": [
+                                              {
+                                                "name": "Data",
+                                                "required": true,
+                                                "schema": {
+                                                  "type": "object",
+                                                  "required": [
+                                                    "data",
+                                                    "data_id",
+                                                    "is_promise_resume"
+                                                  ],
+                                                  "additionalProperties": false,
+                                                  "properties": [
+                                                    {
+                                                      "name": "data",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "data_id",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "is_promise_resume",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "boolean"
+                                                      }
+                                                    }
+                                                  ],
+                                                  "refName": "DataReceiptDocument"
+                                                }
+                                              }
+                                            ],
+                                            "refName": "DataReceiptBody"
+                                          }
+                                        ],
+                                        "refName": "ReceiptBody"
+                                      }
+                                    },
+                                    {
+                                      "name": "receipt_id",
+                                      "required": true,
+                                      "schema": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    {
+                                      "name": "receiver_id",
+                                      "required": true,
+                                      "schema": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  ],
+                                  "refName": "ReceiptDocument"
+                                },
+                                {
+                                  "type": "object",
+                                  "additionalProperties": false,
+                                  "refName": "OmittedReceiptDocument"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "name": "tx_hash",
+                            "required": false,
+                            "schema": {
+                              "type": "string"
+                            }
+                          }
+                        ],
+                        "refName": "ExecutionWithReceipt"
+                      }
+                    },
+                    {
+                      "name": "transaction",
+                      "required": true,
+                      "schema": {
+                        "type": "object",
+                        "required": [
+                          "actions",
+                          "hash",
+                          "nonce",
+                          "priority_fee",
+                          "public_key",
+                          "receiver_id",
+                          "signature",
+                          "signer_id"
+                        ],
+                        "additionalProperties": false,
+                        "properties": [
+                          {
+                            "name": "actions",
+                            "required": true,
+                            "schema": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "additionalProperties": true,
+                                "refName": "ActionDocument"
+                              }
+                            }
+                          },
+                          {
+                            "name": "hash",
+                            "required": true,
+                            "schema": {
+                              "type": "string"
+                            }
+                          },
+                          {
+                            "name": "nonce",
+                            "required": true,
+                            "schema": {
+                              "type": "integer",
+                              "format": "uint64"
+                            }
+                          },
+                          {
+                            "name": "priority_fee",
+                            "required": true,
+                            "schema": {
+                              "type": "integer",
+                              "format": "uint64"
+                            }
+                          },
+                          {
+                            "name": "public_key",
+                            "required": true,
+                            "schema": {
+                              "type": "string"
+                            }
+                          },
+                          {
+                            "name": "receiver_id",
+                            "required": true,
+                            "schema": {
+                              "type": "string"
+                            }
+                          },
+                          {
+                            "name": "signature",
+                            "required": true,
+                            "schema": {
+                              "type": "string"
+                            }
+                          },
+                          {
+                            "name": "signer_id",
+                            "required": true,
+                            "schema": {
+                              "type": "string"
+                            }
+                          }
+                        ],
+                        "refName": "SignedTransactionDocument"
+                      }
+                    }
+                  ],
+                  "refName": "ChunkTransactionWrapper"
+                }
+              }
+            }
+          ],
+          "refName": "ChunkDocument"
         },
         "status": "200"
       },
@@ -21554,8 +26190,1580 @@
         "mediaType": "application/json",
         "schema": {
           "type": "object",
-          "description": "Shard object for the requested shard ID.",
-          "additionalProperties": true
+          "description": "Per-shard payload returned by neardata for a block.",
+          "required": [
+            "chunk",
+            "receipt_execution_outcomes",
+            "shard_id",
+            "state_changes"
+          ],
+          "additionalProperties": false,
+          "properties": [
+            {
+              "name": "chunk",
+              "required": true,
+              "schema": {
+                "type": "object",
+                "description": "Chunk payload returned by neardata for a single shard in a selected block.",
+                "required": [
+                  "author",
+                  "header",
+                  "receipts",
+                  "transactions"
+                ],
+                "additionalProperties": false,
+                "properties": [
+                  {
+                    "name": "author",
+                    "required": true,
+                    "schema": {
+                      "type": "string",
+                      "description": "Chunk producer account ID."
+                    }
+                  },
+                  {
+                    "name": "header",
+                    "required": true,
+                    "schema": {
+                      "type": "object",
+                      "description": "Chunk header object as served by neardata.",
+                      "additionalProperties": true,
+                      "properties": [
+                        {
+                          "name": "chunk_hash",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "name": "gas_limit",
+                          "required": false,
+                          "schema": {
+                            "type": "integer"
+                          }
+                        },
+                        {
+                          "name": "gas_used",
+                          "required": false,
+                          "schema": {
+                            "type": "integer"
+                          }
+                        },
+                        {
+                          "name": "height_created",
+                          "required": false,
+                          "schema": {
+                            "type": "integer",
+                            "format": "uint64"
+                          }
+                        },
+                        {
+                          "name": "height_included",
+                          "required": false,
+                          "schema": {
+                            "type": "integer",
+                            "format": "uint64"
+                          }
+                        },
+                        {
+                          "name": "outcome_root",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "name": "outgoing_receipts_root",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "name": "prev_block_hash",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "name": "shard_id",
+                          "required": false,
+                          "schema": {
+                            "type": "integer",
+                            "format": "uint64"
+                          }
+                        },
+                        {
+                          "name": "tx_root",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        }
+                      ],
+                      "refName": "ChunkHeader"
+                    }
+                  },
+                  {
+                    "name": "receipts",
+                    "required": true,
+                    "schema": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "description": "Receipt object as served by neardata inside a chunk payload.",
+                        "required": [
+                          "predecessor_id",
+                          "priority",
+                          "receipt",
+                          "receipt_id",
+                          "receiver_id"
+                        ],
+                        "additionalProperties": false,
+                        "properties": [
+                          {
+                            "name": "predecessor_id",
+                            "required": true,
+                            "schema": {
+                              "type": "string"
+                            }
+                          },
+                          {
+                            "name": "priority",
+                            "required": true,
+                            "schema": {
+                              "type": "integer",
+                              "format": "uint64"
+                            }
+                          },
+                          {
+                            "name": "receipt",
+                            "required": true,
+                            "schema": {
+                              "oneOf": [
+                                {
+                                  "type": "object",
+                                  "required": [
+                                    "Action"
+                                  ],
+                                  "additionalProperties": false,
+                                  "properties": [
+                                    {
+                                      "name": "Action",
+                                      "required": true,
+                                      "schema": {
+                                        "type": "object",
+                                        "required": [
+                                          "actions",
+                                          "gas_price",
+                                          "input_data_ids",
+                                          "is_promise_yield",
+                                          "output_data_receivers",
+                                          "signer_id",
+                                          "signer_public_key"
+                                        ],
+                                        "additionalProperties": false,
+                                        "properties": [
+                                          {
+                                            "name": "actions",
+                                            "required": true,
+                                            "schema": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "additionalProperties": true,
+                                                "refName": "ActionDocument"
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "name": "gas_price",
+                                            "required": true,
+                                            "schema": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          {
+                                            "name": "input_data_ids",
+                                            "required": true,
+                                            "schema": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "name": "is_promise_yield",
+                                            "required": true,
+                                            "schema": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          {
+                                            "name": "output_data_receivers",
+                                            "required": true,
+                                            "schema": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "required": [
+                                                  "data_id",
+                                                  "receiver_id"
+                                                ],
+                                                "additionalProperties": false,
+                                                "properties": [
+                                                  {
+                                                    "name": "data_id",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "receiver_id",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                ],
+                                                "refName": "OutputDataReceiverDocument"
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "name": "signer_id",
+                                            "required": true,
+                                            "schema": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          {
+                                            "name": "signer_public_key",
+                                            "required": true,
+                                            "schema": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        ],
+                                        "refName": "ActionReceiptDocument"
+                                      }
+                                    }
+                                  ],
+                                  "refName": "ActionReceiptBody"
+                                },
+                                {
+                                  "type": "object",
+                                  "required": [
+                                    "Data"
+                                  ],
+                                  "additionalProperties": false,
+                                  "properties": [
+                                    {
+                                      "name": "Data",
+                                      "required": true,
+                                      "schema": {
+                                        "type": "object",
+                                        "required": [
+                                          "data",
+                                          "data_id",
+                                          "is_promise_resume"
+                                        ],
+                                        "additionalProperties": false,
+                                        "properties": [
+                                          {
+                                            "name": "data",
+                                            "required": true,
+                                            "schema": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          {
+                                            "name": "data_id",
+                                            "required": true,
+                                            "schema": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          {
+                                            "name": "is_promise_resume",
+                                            "required": true,
+                                            "schema": {
+                                              "type": "boolean"
+                                            }
+                                          }
+                                        ],
+                                        "refName": "DataReceiptDocument"
+                                      }
+                                    }
+                                  ],
+                                  "refName": "DataReceiptBody"
+                                }
+                              ],
+                              "refName": "ReceiptBody"
+                            }
+                          },
+                          {
+                            "name": "receipt_id",
+                            "required": true,
+                            "schema": {
+                              "type": "string"
+                            }
+                          },
+                          {
+                            "name": "receiver_id",
+                            "required": true,
+                            "schema": {
+                              "type": "string"
+                            }
+                          }
+                        ],
+                        "refName": "ReceiptDocument"
+                      }
+                    }
+                  },
+                  {
+                    "name": "transactions",
+                    "required": true,
+                    "schema": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "description": "Transaction entry returned inside a neardata chunk.",
+                        "required": [
+                          "outcome",
+                          "transaction"
+                        ],
+                        "additionalProperties": false,
+                        "properties": [
+                          {
+                            "name": "outcome",
+                            "required": true,
+                            "schema": {
+                              "type": "object",
+                              "description": "Execution result paired with an optional receipt object.",
+                              "required": [
+                                "execution_outcome",
+                                "receipt"
+                              ],
+                              "additionalProperties": false,
+                              "properties": [
+                                {
+                                  "name": "execution_outcome",
+                                  "required": true,
+                                  "schema": {
+                                    "type": "object",
+                                    "required": [
+                                      "block_hash",
+                                      "id",
+                                      "outcome",
+                                      "proof"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "block_hash",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "outcome",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "object",
+                                          "required": [
+                                            "executor_id",
+                                            "gas_burnt",
+                                            "logs",
+                                            "metadata",
+                                            "receipt_ids",
+                                            "status",
+                                            "tokens_burnt"
+                                          ],
+                                          "additionalProperties": false,
+                                          "properties": [
+                                            {
+                                              "name": "executor_id",
+                                              "required": true,
+                                              "schema": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            {
+                                              "name": "gas_burnt",
+                                              "required": true,
+                                              "schema": {
+                                                "type": "integer",
+                                                "format": "uint64"
+                                              }
+                                            },
+                                            {
+                                              "name": "logs",
+                                              "required": true,
+                                              "schema": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "name": "metadata",
+                                              "required": true,
+                                              "schema": {
+                                                "type": "object",
+                                                "additionalProperties": true
+                                              }
+                                            },
+                                            {
+                                              "name": "receipt_ids",
+                                              "required": true,
+                                              "schema": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "name": "status",
+                                              "required": true,
+                                              "schema": {
+                                                "oneOf": [
+                                                  {
+                                                    "type": "object",
+                                                    "required": [
+                                                      "SuccessReceiptId"
+                                                    ],
+                                                    "additionalProperties": false,
+                                                    "properties": [
+                                                      {
+                                                        "name": "SuccessReceiptId",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "string"
+                                                        }
+                                                      }
+                                                    ],
+                                                    "refName": "ExecutionOutcomeStatusSuccessReceiptId"
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "required": [
+                                                      "SuccessValue"
+                                                    ],
+                                                    "additionalProperties": false,
+                                                    "properties": [
+                                                      {
+                                                        "name": "SuccessValue",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "string"
+                                                        }
+                                                      }
+                                                    ],
+                                                    "refName": "ExecutionOutcomeStatusSuccessValue"
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "required": [
+                                                      "Failure"
+                                                    ],
+                                                    "additionalProperties": false,
+                                                    "properties": [
+                                                      {
+                                                        "name": "Failure",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "object",
+                                                          "additionalProperties": true
+                                                        }
+                                                      }
+                                                    ],
+                                                    "refName": "ExecutionOutcomeStatusFailure"
+                                                  }
+                                                ],
+                                                "refName": "ExecutionOutcomeStatus"
+                                              }
+                                            },
+                                            {
+                                              "name": "tokens_burnt",
+                                              "required": true,
+                                              "schema": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          ],
+                                          "refName": "ExecutionOutcomeSummary"
+                                        }
+                                      },
+                                      {
+                                        "name": "proof",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "additionalProperties": true,
+                                            "refName": "ExecutionProofItem"
+                                          }
+                                        }
+                                      }
+                                    ],
+                                    "refName": "ExecutionOutcomeDocument"
+                                  }
+                                },
+                                {
+                                  "name": "receipt",
+                                  "required": true,
+                                  "schema": {
+                                    "type": "object",
+                                    "description": "Receipt payload when neardata includes it for this entry.",
+                                    "oneOf": [
+                                      {
+                                        "type": "object",
+                                        "description": "Receipt object as served by neardata inside a chunk payload.",
+                                        "required": [
+                                          "predecessor_id",
+                                          "priority",
+                                          "receipt",
+                                          "receipt_id",
+                                          "receiver_id"
+                                        ],
+                                        "additionalProperties": false,
+                                        "properties": [
+                                          {
+                                            "name": "predecessor_id",
+                                            "required": true,
+                                            "schema": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          {
+                                            "name": "priority",
+                                            "required": true,
+                                            "schema": {
+                                              "type": "integer",
+                                              "format": "uint64"
+                                            }
+                                          },
+                                          {
+                                            "name": "receipt",
+                                            "required": true,
+                                            "schema": {
+                                              "oneOf": [
+                                                {
+                                                  "type": "object",
+                                                  "required": [
+                                                    "Action"
+                                                  ],
+                                                  "additionalProperties": false,
+                                                  "properties": [
+                                                    {
+                                                      "name": "Action",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "object",
+                                                        "required": [
+                                                          "actions",
+                                                          "gas_price",
+                                                          "input_data_ids",
+                                                          "is_promise_yield",
+                                                          "output_data_receivers",
+                                                          "signer_id",
+                                                          "signer_public_key"
+                                                        ],
+                                                        "additionalProperties": false,
+                                                        "properties": [
+                                                          {
+                                                            "name": "actions",
+                                                            "required": true,
+                                                            "schema": {
+                                                              "type": "array",
+                                                              "items": {
+                                                                "type": "object",
+                                                                "additionalProperties": true,
+                                                                "refName": "ActionDocument"
+                                                              }
+                                                            }
+                                                          },
+                                                          {
+                                                            "name": "gas_price",
+                                                            "required": true,
+                                                            "schema": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          {
+                                                            "name": "input_data_ids",
+                                                            "required": true,
+                                                            "schema": {
+                                                              "type": "array",
+                                                              "items": {
+                                                                "type": "string"
+                                                              }
+                                                            }
+                                                          },
+                                                          {
+                                                            "name": "is_promise_yield",
+                                                            "required": true,
+                                                            "schema": {
+                                                              "type": "boolean"
+                                                            }
+                                                          },
+                                                          {
+                                                            "name": "output_data_receivers",
+                                                            "required": true,
+                                                            "schema": {
+                                                              "type": "array",
+                                                              "items": {
+                                                                "type": "object",
+                                                                "required": [
+                                                                  "data_id",
+                                                                  "receiver_id"
+                                                                ],
+                                                                "additionalProperties": false,
+                                                                "properties": [
+                                                                  {
+                                                                    "name": "data_id",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "receiver_id",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  }
+                                                                ],
+                                                                "refName": "OutputDataReceiverDocument"
+                                                              }
+                                                            }
+                                                          },
+                                                          {
+                                                            "name": "signer_id",
+                                                            "required": true,
+                                                            "schema": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          {
+                                                            "name": "signer_public_key",
+                                                            "required": true,
+                                                            "schema": {
+                                                              "type": "string"
+                                                            }
+                                                          }
+                                                        ],
+                                                        "refName": "ActionReceiptDocument"
+                                                      }
+                                                    }
+                                                  ],
+                                                  "refName": "ActionReceiptBody"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "required": [
+                                                    "Data"
+                                                  ],
+                                                  "additionalProperties": false,
+                                                  "properties": [
+                                                    {
+                                                      "name": "Data",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "object",
+                                                        "required": [
+                                                          "data",
+                                                          "data_id",
+                                                          "is_promise_resume"
+                                                        ],
+                                                        "additionalProperties": false,
+                                                        "properties": [
+                                                          {
+                                                            "name": "data",
+                                                            "required": true,
+                                                            "schema": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          {
+                                                            "name": "data_id",
+                                                            "required": true,
+                                                            "schema": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          {
+                                                            "name": "is_promise_resume",
+                                                            "required": true,
+                                                            "schema": {
+                                                              "type": "boolean"
+                                                            }
+                                                          }
+                                                        ],
+                                                        "refName": "DataReceiptDocument"
+                                                      }
+                                                    }
+                                                  ],
+                                                  "refName": "DataReceiptBody"
+                                                }
+                                              ],
+                                              "refName": "ReceiptBody"
+                                            }
+                                          },
+                                          {
+                                            "name": "receipt_id",
+                                            "required": true,
+                                            "schema": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          {
+                                            "name": "receiver_id",
+                                            "required": true,
+                                            "schema": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        ],
+                                        "refName": "ReceiptDocument"
+                                      },
+                                      {
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "refName": "OmittedReceiptDocument"
+                                      }
+                                    ]
+                                  }
+                                },
+                                {
+                                  "name": "tx_hash",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "string"
+                                  }
+                                }
+                              ],
+                              "refName": "ExecutionWithReceipt"
+                            }
+                          },
+                          {
+                            "name": "transaction",
+                            "required": true,
+                            "schema": {
+                              "type": "object",
+                              "required": [
+                                "actions",
+                                "hash",
+                                "nonce",
+                                "priority_fee",
+                                "public_key",
+                                "receiver_id",
+                                "signature",
+                                "signer_id"
+                              ],
+                              "additionalProperties": false,
+                              "properties": [
+                                {
+                                  "name": "actions",
+                                  "required": true,
+                                  "schema": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "additionalProperties": true,
+                                      "refName": "ActionDocument"
+                                    }
+                                  }
+                                },
+                                {
+                                  "name": "hash",
+                                  "required": true,
+                                  "schema": {
+                                    "type": "string"
+                                  }
+                                },
+                                {
+                                  "name": "nonce",
+                                  "required": true,
+                                  "schema": {
+                                    "type": "integer",
+                                    "format": "uint64"
+                                  }
+                                },
+                                {
+                                  "name": "priority_fee",
+                                  "required": true,
+                                  "schema": {
+                                    "type": "integer",
+                                    "format": "uint64"
+                                  }
+                                },
+                                {
+                                  "name": "public_key",
+                                  "required": true,
+                                  "schema": {
+                                    "type": "string"
+                                  }
+                                },
+                                {
+                                  "name": "receiver_id",
+                                  "required": true,
+                                  "schema": {
+                                    "type": "string"
+                                  }
+                                },
+                                {
+                                  "name": "signature",
+                                  "required": true,
+                                  "schema": {
+                                    "type": "string"
+                                  }
+                                },
+                                {
+                                  "name": "signer_id",
+                                  "required": true,
+                                  "schema": {
+                                    "type": "string"
+                                  }
+                                }
+                              ],
+                              "refName": "SignedTransactionDocument"
+                            }
+                          }
+                        ],
+                        "refName": "ChunkTransactionWrapper"
+                      }
+                    }
+                  }
+                ],
+                "refName": "ChunkDocument"
+              }
+            },
+            {
+              "name": "receipt_execution_outcomes",
+              "required": true,
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "description": "Execution result paired with an optional receipt object.",
+                  "required": [
+                    "execution_outcome",
+                    "receipt"
+                  ],
+                  "additionalProperties": false,
+                  "properties": [
+                    {
+                      "name": "execution_outcome",
+                      "required": true,
+                      "schema": {
+                        "type": "object",
+                        "required": [
+                          "block_hash",
+                          "id",
+                          "outcome",
+                          "proof"
+                        ],
+                        "additionalProperties": false,
+                        "properties": [
+                          {
+                            "name": "block_hash",
+                            "required": true,
+                            "schema": {
+                              "type": "string"
+                            }
+                          },
+                          {
+                            "name": "id",
+                            "required": true,
+                            "schema": {
+                              "type": "string"
+                            }
+                          },
+                          {
+                            "name": "outcome",
+                            "required": true,
+                            "schema": {
+                              "type": "object",
+                              "required": [
+                                "executor_id",
+                                "gas_burnt",
+                                "logs",
+                                "metadata",
+                                "receipt_ids",
+                                "status",
+                                "tokens_burnt"
+                              ],
+                              "additionalProperties": false,
+                              "properties": [
+                                {
+                                  "name": "executor_id",
+                                  "required": true,
+                                  "schema": {
+                                    "type": "string"
+                                  }
+                                },
+                                {
+                                  "name": "gas_burnt",
+                                  "required": true,
+                                  "schema": {
+                                    "type": "integer",
+                                    "format": "uint64"
+                                  }
+                                },
+                                {
+                                  "name": "logs",
+                                  "required": true,
+                                  "schema": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                {
+                                  "name": "metadata",
+                                  "required": true,
+                                  "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                  }
+                                },
+                                {
+                                  "name": "receipt_ids",
+                                  "required": true,
+                                  "schema": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                {
+                                  "name": "status",
+                                  "required": true,
+                                  "schema": {
+                                    "oneOf": [
+                                      {
+                                        "type": "object",
+                                        "required": [
+                                          "SuccessReceiptId"
+                                        ],
+                                        "additionalProperties": false,
+                                        "properties": [
+                                          {
+                                            "name": "SuccessReceiptId",
+                                            "required": true,
+                                            "schema": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        ],
+                                        "refName": "ExecutionOutcomeStatusSuccessReceiptId"
+                                      },
+                                      {
+                                        "type": "object",
+                                        "required": [
+                                          "SuccessValue"
+                                        ],
+                                        "additionalProperties": false,
+                                        "properties": [
+                                          {
+                                            "name": "SuccessValue",
+                                            "required": true,
+                                            "schema": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        ],
+                                        "refName": "ExecutionOutcomeStatusSuccessValue"
+                                      },
+                                      {
+                                        "type": "object",
+                                        "required": [
+                                          "Failure"
+                                        ],
+                                        "additionalProperties": false,
+                                        "properties": [
+                                          {
+                                            "name": "Failure",
+                                            "required": true,
+                                            "schema": {
+                                              "type": "object",
+                                              "additionalProperties": true
+                                            }
+                                          }
+                                        ],
+                                        "refName": "ExecutionOutcomeStatusFailure"
+                                      }
+                                    ],
+                                    "refName": "ExecutionOutcomeStatus"
+                                  }
+                                },
+                                {
+                                  "name": "tokens_burnt",
+                                  "required": true,
+                                  "schema": {
+                                    "type": "string"
+                                  }
+                                }
+                              ],
+                              "refName": "ExecutionOutcomeSummary"
+                            }
+                          },
+                          {
+                            "name": "proof",
+                            "required": true,
+                            "schema": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "additionalProperties": true,
+                                "refName": "ExecutionProofItem"
+                              }
+                            }
+                          }
+                        ],
+                        "refName": "ExecutionOutcomeDocument"
+                      }
+                    },
+                    {
+                      "name": "receipt",
+                      "required": true,
+                      "schema": {
+                        "type": "object",
+                        "description": "Receipt payload when neardata includes it for this entry.",
+                        "oneOf": [
+                          {
+                            "type": "object",
+                            "description": "Receipt object as served by neardata inside a chunk payload.",
+                            "required": [
+                              "predecessor_id",
+                              "priority",
+                              "receipt",
+                              "receipt_id",
+                              "receiver_id"
+                            ],
+                            "additionalProperties": false,
+                            "properties": [
+                              {
+                                "name": "predecessor_id",
+                                "required": true,
+                                "schema": {
+                                  "type": "string"
+                                }
+                              },
+                              {
+                                "name": "priority",
+                                "required": true,
+                                "schema": {
+                                  "type": "integer",
+                                  "format": "uint64"
+                                }
+                              },
+                              {
+                                "name": "receipt",
+                                "required": true,
+                                "schema": {
+                                  "oneOf": [
+                                    {
+                                      "type": "object",
+                                      "required": [
+                                        "Action"
+                                      ],
+                                      "additionalProperties": false,
+                                      "properties": [
+                                        {
+                                          "name": "Action",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "object",
+                                            "required": [
+                                              "actions",
+                                              "gas_price",
+                                              "input_data_ids",
+                                              "is_promise_yield",
+                                              "output_data_receivers",
+                                              "signer_id",
+                                              "signer_public_key"
+                                            ],
+                                            "additionalProperties": false,
+                                            "properties": [
+                                              {
+                                                "name": "actions",
+                                                "required": true,
+                                                "schema": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "object",
+                                                    "additionalProperties": true,
+                                                    "refName": "ActionDocument"
+                                                  }
+                                                }
+                                              },
+                                              {
+                                                "name": "gas_price",
+                                                "required": true,
+                                                "schema": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              {
+                                                "name": "input_data_ids",
+                                                "required": true,
+                                                "schema": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              },
+                                              {
+                                                "name": "is_promise_yield",
+                                                "required": true,
+                                                "schema": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              {
+                                                "name": "output_data_receivers",
+                                                "required": true,
+                                                "schema": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "object",
+                                                    "required": [
+                                                      "data_id",
+                                                      "receiver_id"
+                                                    ],
+                                                    "additionalProperties": false,
+                                                    "properties": [
+                                                      {
+                                                        "name": "data_id",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "receiver_id",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "string"
+                                                        }
+                                                      }
+                                                    ],
+                                                    "refName": "OutputDataReceiverDocument"
+                                                  }
+                                                }
+                                              },
+                                              {
+                                                "name": "signer_id",
+                                                "required": true,
+                                                "schema": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              {
+                                                "name": "signer_public_key",
+                                                "required": true,
+                                                "schema": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            ],
+                                            "refName": "ActionReceiptDocument"
+                                          }
+                                        }
+                                      ],
+                                      "refName": "ActionReceiptBody"
+                                    },
+                                    {
+                                      "type": "object",
+                                      "required": [
+                                        "Data"
+                                      ],
+                                      "additionalProperties": false,
+                                      "properties": [
+                                        {
+                                          "name": "Data",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "object",
+                                            "required": [
+                                              "data",
+                                              "data_id",
+                                              "is_promise_resume"
+                                            ],
+                                            "additionalProperties": false,
+                                            "properties": [
+                                              {
+                                                "name": "data",
+                                                "required": true,
+                                                "schema": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              {
+                                                "name": "data_id",
+                                                "required": true,
+                                                "schema": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              {
+                                                "name": "is_promise_resume",
+                                                "required": true,
+                                                "schema": {
+                                                  "type": "boolean"
+                                                }
+                                              }
+                                            ],
+                                            "refName": "DataReceiptDocument"
+                                          }
+                                        }
+                                      ],
+                                      "refName": "DataReceiptBody"
+                                    }
+                                  ],
+                                  "refName": "ReceiptBody"
+                                }
+                              },
+                              {
+                                "name": "receipt_id",
+                                "required": true,
+                                "schema": {
+                                  "type": "string"
+                                }
+                              },
+                              {
+                                "name": "receiver_id",
+                                "required": true,
+                                "schema": {
+                                  "type": "string"
+                                }
+                              }
+                            ],
+                            "refName": "ReceiptDocument"
+                          },
+                          {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "refName": "OmittedReceiptDocument"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "tx_hash",
+                      "required": false,
+                      "schema": {
+                        "type": "string"
+                      }
+                    }
+                  ],
+                  "refName": "ExecutionWithReceipt"
+                }
+              }
+            },
+            {
+              "name": "shard_id",
+              "required": true,
+              "schema": {
+                "type": "integer",
+                "format": "uint64"
+              }
+            },
+            {
+              "name": "state_changes",
+              "required": true,
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "description": "State change entry returned by neardata for a shard.",
+                  "required": [
+                    "cause",
+                    "change",
+                    "type"
+                  ],
+                  "additionalProperties": false,
+                  "properties": [
+                    {
+                      "name": "cause",
+                      "required": true,
+                      "schema": {
+                        "oneOf": [
+                          {
+                            "type": "object",
+                            "required": [
+                              "tx_hash",
+                              "type"
+                            ],
+                            "additionalProperties": false,
+                            "properties": [
+                              {
+                                "name": "tx_hash",
+                                "required": true,
+                                "schema": {
+                                  "type": "string"
+                                }
+                              },
+                              {
+                                "name": "type",
+                                "required": true,
+                                "schema": {
+                                  "type": "string"
+                                }
+                              }
+                            ],
+                            "refName": "StateChangeCauseTransactionProcessing"
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "receipt_hash",
+                              "type"
+                            ],
+                            "additionalProperties": false,
+                            "properties": [
+                              {
+                                "name": "receipt_hash",
+                                "required": true,
+                                "schema": {
+                                  "type": "string"
+                                }
+                              },
+                              {
+                                "name": "type",
+                                "required": true,
+                                "schema": {
+                                  "type": "string"
+                                }
+                              }
+                            ],
+                            "refName": "StateChangeCauseReceiptProcessing"
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "receipt_hash",
+                              "type"
+                            ],
+                            "additionalProperties": false,
+                            "properties": [
+                              {
+                                "name": "receipt_hash",
+                                "required": true,
+                                "schema": {
+                                  "type": "string"
+                                }
+                              },
+                              {
+                                "name": "type",
+                                "required": true,
+                                "schema": {
+                                  "type": "string"
+                                }
+                              }
+                            ],
+                            "refName": "StateChangeCauseActionReceiptGasReward"
+                          }
+                        ],
+                        "refName": "StateChangeCause"
+                      }
+                    },
+                    {
+                      "name": "change",
+                      "required": true,
+                      "schema": {
+                        "oneOf": [
+                          {
+                            "type": "object",
+                            "required": [
+                              "account_id",
+                              "amount",
+                              "code_hash",
+                              "locked",
+                              "storage_paid_at",
+                              "storage_usage"
+                            ],
+                            "additionalProperties": false,
+                            "properties": [
+                              {
+                                "name": "account_id",
+                                "required": true,
+                                "schema": {
+                                  "type": "string"
+                                }
+                              },
+                              {
+                                "name": "amount",
+                                "required": true,
+                                "schema": {
+                                  "type": "string"
+                                }
+                              },
+                              {
+                                "name": "code_hash",
+                                "required": true,
+                                "schema": {
+                                  "type": "string"
+                                }
+                              },
+                              {
+                                "name": "locked",
+                                "required": true,
+                                "schema": {
+                                  "type": "string"
+                                }
+                              },
+                              {
+                                "name": "storage_paid_at",
+                                "required": true,
+                                "schema": {
+                                  "type": "integer",
+                                  "format": "uint64"
+                                }
+                              },
+                              {
+                                "name": "storage_usage",
+                                "required": true,
+                                "schema": {
+                                  "type": "integer",
+                                  "format": "uint64"
+                                }
+                              }
+                            ],
+                            "refName": "StateChangeValueAccountUpdate"
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "access_key",
+                              "account_id",
+                              "public_key"
+                            ],
+                            "additionalProperties": false,
+                            "properties": [
+                              {
+                                "name": "access_key",
+                                "required": true,
+                                "schema": {
+                                  "type": "object",
+                                  "additionalProperties": true
+                                }
+                              },
+                              {
+                                "name": "account_id",
+                                "required": true,
+                                "schema": {
+                                  "type": "string"
+                                }
+                              },
+                              {
+                                "name": "public_key",
+                                "required": true,
+                                "schema": {
+                                  "type": "string"
+                                }
+                              }
+                            ],
+                            "refName": "StateChangeValueAccessKeyUpdate"
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "account_id",
+                              "key_base64",
+                              "value_base64"
+                            ],
+                            "additionalProperties": false,
+                            "properties": [
+                              {
+                                "name": "account_id",
+                                "required": true,
+                                "schema": {
+                                  "type": "string"
+                                }
+                              },
+                              {
+                                "name": "key_base64",
+                                "required": true,
+                                "schema": {
+                                  "type": "string"
+                                }
+                              },
+                              {
+                                "name": "value_base64",
+                                "required": true,
+                                "schema": {
+                                  "type": "string"
+                                }
+                              }
+                            ],
+                            "refName": "StateChangeValueDataUpdate"
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "account_id",
+                              "key_base64"
+                            ],
+                            "additionalProperties": false,
+                            "properties": [
+                              {
+                                "name": "account_id",
+                                "required": true,
+                                "schema": {
+                                  "type": "string"
+                                }
+                              },
+                              {
+                                "name": "key_base64",
+                                "required": true,
+                                "schema": {
+                                  "type": "string"
+                                }
+                              }
+                            ],
+                            "refName": "StateChangeValueDataDeletion"
+                          }
+                        ],
+                        "refName": "StateChangeValue"
+                      }
+                    },
+                    {
+                      "name": "type",
+                      "required": true,
+                      "schema": {
+                        "type": "string"
+                      }
+                    }
+                  ],
+                  "refName": "StateChangeItem"
+                }
+              }
+            }
+          ],
+          "refName": "ShardDocument"
         },
         "status": "200"
       },
@@ -21750,8 +27958,1804 @@
         "mediaType": "application/json",
         "schema": {
           "type": "object",
-          "description": "Full block document as served by neardata, including `block` and `shards`.",
-          "additionalProperties": true
+          "description": "Full block document as served by neardata, including the block envelope and per-shard payloads.",
+          "required": [
+            "block",
+            "shards"
+          ],
+          "additionalProperties": false,
+          "properties": [
+            {
+              "name": "block",
+              "required": true,
+              "schema": {
+                "type": "object",
+                "description": "Block-level payload returned by neardata.",
+                "required": [
+                  "author",
+                  "chunks",
+                  "header"
+                ],
+                "additionalProperties": false,
+                "properties": [
+                  {
+                    "name": "author",
+                    "required": true,
+                    "schema": {
+                      "type": "string",
+                      "description": "Block producer account ID."
+                    }
+                  },
+                  {
+                    "name": "chunks",
+                    "required": true,
+                    "schema": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "description": "Chunk header object as served by neardata.",
+                        "additionalProperties": true,
+                        "properties": [
+                          {
+                            "name": "chunk_hash",
+                            "required": false,
+                            "schema": {
+                              "type": "string"
+                            }
+                          },
+                          {
+                            "name": "gas_limit",
+                            "required": false,
+                            "schema": {
+                              "type": "integer"
+                            }
+                          },
+                          {
+                            "name": "gas_used",
+                            "required": false,
+                            "schema": {
+                              "type": "integer"
+                            }
+                          },
+                          {
+                            "name": "height_created",
+                            "required": false,
+                            "schema": {
+                              "type": "integer",
+                              "format": "uint64"
+                            }
+                          },
+                          {
+                            "name": "height_included",
+                            "required": false,
+                            "schema": {
+                              "type": "integer",
+                              "format": "uint64"
+                            }
+                          },
+                          {
+                            "name": "outcome_root",
+                            "required": false,
+                            "schema": {
+                              "type": "string"
+                            }
+                          },
+                          {
+                            "name": "outgoing_receipts_root",
+                            "required": false,
+                            "schema": {
+                              "type": "string"
+                            }
+                          },
+                          {
+                            "name": "prev_block_hash",
+                            "required": false,
+                            "schema": {
+                              "type": "string"
+                            }
+                          },
+                          {
+                            "name": "shard_id",
+                            "required": false,
+                            "schema": {
+                              "type": "integer",
+                              "format": "uint64"
+                            }
+                          },
+                          {
+                            "name": "tx_root",
+                            "required": false,
+                            "schema": {
+                              "type": "string"
+                            }
+                          }
+                        ],
+                        "refName": "ChunkHeader"
+                      }
+                    }
+                  },
+                  {
+                    "name": "header",
+                    "required": true,
+                    "schema": {
+                      "type": "object",
+                      "description": "Block header object as served by neardata.",
+                      "additionalProperties": true,
+                      "properties": [
+                        {
+                          "name": "chunks_included",
+                          "required": false,
+                          "schema": {
+                            "type": "integer",
+                            "format": "uint64"
+                          }
+                        },
+                        {
+                          "name": "epoch_id",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "name": "gas_price",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "name": "hash",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "name": "height",
+                          "required": false,
+                          "schema": {
+                            "type": "integer",
+                            "format": "uint64"
+                          }
+                        },
+                        {
+                          "name": "next_epoch_id",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "name": "prev_hash",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "name": "prev_height",
+                          "required": false,
+                          "schema": {
+                            "type": "integer",
+                            "format": "uint64"
+                          }
+                        },
+                        {
+                          "name": "timestamp",
+                          "required": false,
+                          "schema": {
+                            "type": "integer"
+                          }
+                        },
+                        {
+                          "name": "timestamp_nanosec",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "name": "total_supply",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        }
+                      ],
+                      "refName": "BlockHeader"
+                    }
+                  }
+                ],
+                "refName": "BlockEnvelope"
+              }
+            },
+            {
+              "name": "shards",
+              "required": true,
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "description": "Per-shard payload returned by neardata for a block.",
+                  "required": [
+                    "chunk",
+                    "receipt_execution_outcomes",
+                    "shard_id",
+                    "state_changes"
+                  ],
+                  "additionalProperties": false,
+                  "properties": [
+                    {
+                      "name": "chunk",
+                      "required": true,
+                      "schema": {
+                        "type": "object",
+                        "description": "Chunk payload returned by neardata for a single shard in a selected block.",
+                        "required": [
+                          "author",
+                          "header",
+                          "receipts",
+                          "transactions"
+                        ],
+                        "additionalProperties": false,
+                        "properties": [
+                          {
+                            "name": "author",
+                            "required": true,
+                            "schema": {
+                              "type": "string",
+                              "description": "Chunk producer account ID."
+                            }
+                          },
+                          {
+                            "name": "header",
+                            "required": true,
+                            "schema": {
+                              "type": "object",
+                              "description": "Chunk header object as served by neardata.",
+                              "additionalProperties": true,
+                              "properties": [
+                                {
+                                  "name": "chunk_hash",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "string"
+                                  }
+                                },
+                                {
+                                  "name": "gas_limit",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "integer"
+                                  }
+                                },
+                                {
+                                  "name": "gas_used",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "integer"
+                                  }
+                                },
+                                {
+                                  "name": "height_created",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "integer",
+                                    "format": "uint64"
+                                  }
+                                },
+                                {
+                                  "name": "height_included",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "integer",
+                                    "format": "uint64"
+                                  }
+                                },
+                                {
+                                  "name": "outcome_root",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "string"
+                                  }
+                                },
+                                {
+                                  "name": "outgoing_receipts_root",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "string"
+                                  }
+                                },
+                                {
+                                  "name": "prev_block_hash",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "string"
+                                  }
+                                },
+                                {
+                                  "name": "shard_id",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "integer",
+                                    "format": "uint64"
+                                  }
+                                },
+                                {
+                                  "name": "tx_root",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "string"
+                                  }
+                                }
+                              ],
+                              "refName": "ChunkHeader"
+                            }
+                          },
+                          {
+                            "name": "receipts",
+                            "required": true,
+                            "schema": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "description": "Receipt object as served by neardata inside a chunk payload.",
+                                "required": [
+                                  "predecessor_id",
+                                  "priority",
+                                  "receipt",
+                                  "receipt_id",
+                                  "receiver_id"
+                                ],
+                                "additionalProperties": false,
+                                "properties": [
+                                  {
+                                    "name": "predecessor_id",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  {
+                                    "name": "priority",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "integer",
+                                      "format": "uint64"
+                                    }
+                                  },
+                                  {
+                                    "name": "receipt",
+                                    "required": true,
+                                    "schema": {
+                                      "oneOf": [
+                                        {
+                                          "type": "object",
+                                          "required": [
+                                            "Action"
+                                          ],
+                                          "additionalProperties": false,
+                                          "properties": [
+                                            {
+                                              "name": "Action",
+                                              "required": true,
+                                              "schema": {
+                                                "type": "object",
+                                                "required": [
+                                                  "actions",
+                                                  "gas_price",
+                                                  "input_data_ids",
+                                                  "is_promise_yield",
+                                                  "output_data_receivers",
+                                                  "signer_id",
+                                                  "signer_public_key"
+                                                ],
+                                                "additionalProperties": false,
+                                                "properties": [
+                                                  {
+                                                    "name": "actions",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "object",
+                                                        "additionalProperties": true,
+                                                        "refName": "ActionDocument"
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "gas_price",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "input_data_ids",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "is_promise_yield",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "output_data_receivers",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "object",
+                                                        "required": [
+                                                          "data_id",
+                                                          "receiver_id"
+                                                        ],
+                                                        "additionalProperties": false,
+                                                        "properties": [
+                                                          {
+                                                            "name": "data_id",
+                                                            "required": true,
+                                                            "schema": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          {
+                                                            "name": "receiver_id",
+                                                            "required": true,
+                                                            "schema": {
+                                                              "type": "string"
+                                                            }
+                                                          }
+                                                        ],
+                                                        "refName": "OutputDataReceiverDocument"
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "signer_id",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "signer_public_key",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                ],
+                                                "refName": "ActionReceiptDocument"
+                                              }
+                                            }
+                                          ],
+                                          "refName": "ActionReceiptBody"
+                                        },
+                                        {
+                                          "type": "object",
+                                          "required": [
+                                            "Data"
+                                          ],
+                                          "additionalProperties": false,
+                                          "properties": [
+                                            {
+                                              "name": "Data",
+                                              "required": true,
+                                              "schema": {
+                                                "type": "object",
+                                                "required": [
+                                                  "data",
+                                                  "data_id",
+                                                  "is_promise_resume"
+                                                ],
+                                                "additionalProperties": false,
+                                                "properties": [
+                                                  {
+                                                    "name": "data",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "data_id",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "is_promise_resume",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "boolean"
+                                                    }
+                                                  }
+                                                ],
+                                                "refName": "DataReceiptDocument"
+                                              }
+                                            }
+                                          ],
+                                          "refName": "DataReceiptBody"
+                                        }
+                                      ],
+                                      "refName": "ReceiptBody"
+                                    }
+                                  },
+                                  {
+                                    "name": "receipt_id",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  {
+                                    "name": "receiver_id",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "string"
+                                    }
+                                  }
+                                ],
+                                "refName": "ReceiptDocument"
+                              }
+                            }
+                          },
+                          {
+                            "name": "transactions",
+                            "required": true,
+                            "schema": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "description": "Transaction entry returned inside a neardata chunk.",
+                                "required": [
+                                  "outcome",
+                                  "transaction"
+                                ],
+                                "additionalProperties": false,
+                                "properties": [
+                                  {
+                                    "name": "outcome",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "object",
+                                      "description": "Execution result paired with an optional receipt object.",
+                                      "required": [
+                                        "execution_outcome",
+                                        "receipt"
+                                      ],
+                                      "additionalProperties": false,
+                                      "properties": [
+                                        {
+                                          "name": "execution_outcome",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "object",
+                                            "required": [
+                                              "block_hash",
+                                              "id",
+                                              "outcome",
+                                              "proof"
+                                            ],
+                                            "additionalProperties": false,
+                                            "properties": [
+                                              {
+                                                "name": "block_hash",
+                                                "required": true,
+                                                "schema": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              {
+                                                "name": "id",
+                                                "required": true,
+                                                "schema": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              {
+                                                "name": "outcome",
+                                                "required": true,
+                                                "schema": {
+                                                  "type": "object",
+                                                  "required": [
+                                                    "executor_id",
+                                                    "gas_burnt",
+                                                    "logs",
+                                                    "metadata",
+                                                    "receipt_ids",
+                                                    "status",
+                                                    "tokens_burnt"
+                                                  ],
+                                                  "additionalProperties": false,
+                                                  "properties": [
+                                                    {
+                                                      "name": "executor_id",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "gas_burnt",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "integer",
+                                                        "format": "uint64"
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "logs",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "metadata",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "object",
+                                                        "additionalProperties": true
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "receipt_ids",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "status",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "oneOf": [
+                                                          {
+                                                            "type": "object",
+                                                            "required": [
+                                                              "SuccessReceiptId"
+                                                            ],
+                                                            "additionalProperties": false,
+                                                            "properties": [
+                                                              {
+                                                                "name": "SuccessReceiptId",
+                                                                "required": true,
+                                                                "schema": {
+                                                                  "type": "string"
+                                                                }
+                                                              }
+                                                            ],
+                                                            "refName": "ExecutionOutcomeStatusSuccessReceiptId"
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "required": [
+                                                              "SuccessValue"
+                                                            ],
+                                                            "additionalProperties": false,
+                                                            "properties": [
+                                                              {
+                                                                "name": "SuccessValue",
+                                                                "required": true,
+                                                                "schema": {
+                                                                  "type": "string"
+                                                                }
+                                                              }
+                                                            ],
+                                                            "refName": "ExecutionOutcomeStatusSuccessValue"
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "required": [
+                                                              "Failure"
+                                                            ],
+                                                            "additionalProperties": false,
+                                                            "properties": [
+                                                              {
+                                                                "name": "Failure",
+                                                                "required": true,
+                                                                "schema": {
+                                                                  "type": "object",
+                                                                  "additionalProperties": true
+                                                                }
+                                                              }
+                                                            ],
+                                                            "refName": "ExecutionOutcomeStatusFailure"
+                                                          }
+                                                        ],
+                                                        "refName": "ExecutionOutcomeStatus"
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "tokens_burnt",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  ],
+                                                  "refName": "ExecutionOutcomeSummary"
+                                                }
+                                              },
+                                              {
+                                                "name": "proof",
+                                                "required": true,
+                                                "schema": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "object",
+                                                    "additionalProperties": true,
+                                                    "refName": "ExecutionProofItem"
+                                                  }
+                                                }
+                                              }
+                                            ],
+                                            "refName": "ExecutionOutcomeDocument"
+                                          }
+                                        },
+                                        {
+                                          "name": "receipt",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "object",
+                                            "description": "Receipt payload when neardata includes it for this entry.",
+                                            "oneOf": [
+                                              {
+                                                "type": "object",
+                                                "description": "Receipt object as served by neardata inside a chunk payload.",
+                                                "required": [
+                                                  "predecessor_id",
+                                                  "priority",
+                                                  "receipt",
+                                                  "receipt_id",
+                                                  "receiver_id"
+                                                ],
+                                                "additionalProperties": false,
+                                                "properties": [
+                                                  {
+                                                    "name": "predecessor_id",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "priority",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "integer",
+                                                      "format": "uint64"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "receipt",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "oneOf": [
+                                                        {
+                                                          "type": "object",
+                                                          "required": [
+                                                            "Action"
+                                                          ],
+                                                          "additionalProperties": false,
+                                                          "properties": [
+                                                            {
+                                                              "name": "Action",
+                                                              "required": true,
+                                                              "schema": {
+                                                                "type": "object",
+                                                                "required": [
+                                                                  "actions",
+                                                                  "gas_price",
+                                                                  "input_data_ids",
+                                                                  "is_promise_yield",
+                                                                  "output_data_receivers",
+                                                                  "signer_id",
+                                                                  "signer_public_key"
+                                                                ],
+                                                                "additionalProperties": false,
+                                                                "properties": [
+                                                                  {
+                                                                    "name": "actions",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "array",
+                                                                      "items": {
+                                                                        "type": "object",
+                                                                        "additionalProperties": true,
+                                                                        "refName": "ActionDocument"
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "gas_price",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "input_data_ids",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "array",
+                                                                      "items": {
+                                                                        "type": "string"
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "is_promise_yield",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "boolean"
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "output_data_receivers",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "array",
+                                                                      "items": {
+                                                                        "type": "object",
+                                                                        "required": [
+                                                                          "data_id",
+                                                                          "receiver_id"
+                                                                        ],
+                                                                        "additionalProperties": false,
+                                                                        "properties": [
+                                                                          {
+                                                                            "name": "data_id",
+                                                                            "required": true,
+                                                                            "schema": {
+                                                                              "type": "string"
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "name": "receiver_id",
+                                                                            "required": true,
+                                                                            "schema": {
+                                                                              "type": "string"
+                                                                            }
+                                                                          }
+                                                                        ],
+                                                                        "refName": "OutputDataReceiverDocument"
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "signer_id",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "signer_public_key",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  }
+                                                                ],
+                                                                "refName": "ActionReceiptDocument"
+                                                              }
+                                                            }
+                                                          ],
+                                                          "refName": "ActionReceiptBody"
+                                                        },
+                                                        {
+                                                          "type": "object",
+                                                          "required": [
+                                                            "Data"
+                                                          ],
+                                                          "additionalProperties": false,
+                                                          "properties": [
+                                                            {
+                                                              "name": "Data",
+                                                              "required": true,
+                                                              "schema": {
+                                                                "type": "object",
+                                                                "required": [
+                                                                  "data",
+                                                                  "data_id",
+                                                                  "is_promise_resume"
+                                                                ],
+                                                                "additionalProperties": false,
+                                                                "properties": [
+                                                                  {
+                                                                    "name": "data",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "data_id",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "is_promise_resume",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "boolean"
+                                                                    }
+                                                                  }
+                                                                ],
+                                                                "refName": "DataReceiptDocument"
+                                                              }
+                                                            }
+                                                          ],
+                                                          "refName": "DataReceiptBody"
+                                                        }
+                                                      ],
+                                                      "refName": "ReceiptBody"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "receipt_id",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "receiver_id",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                ],
+                                                "refName": "ReceiptDocument"
+                                              },
+                                              {
+                                                "type": "object",
+                                                "additionalProperties": false,
+                                                "refName": "OmittedReceiptDocument"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "name": "tx_hash",
+                                          "required": false,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      ],
+                                      "refName": "ExecutionWithReceipt"
+                                    }
+                                  },
+                                  {
+                                    "name": "transaction",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "object",
+                                      "required": [
+                                        "actions",
+                                        "hash",
+                                        "nonce",
+                                        "priority_fee",
+                                        "public_key",
+                                        "receiver_id",
+                                        "signature",
+                                        "signer_id"
+                                      ],
+                                      "additionalProperties": false,
+                                      "properties": [
+                                        {
+                                          "name": "actions",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "additionalProperties": true,
+                                              "refName": "ActionDocument"
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "name": "hash",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        {
+                                          "name": "nonce",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "integer",
+                                            "format": "uint64"
+                                          }
+                                        },
+                                        {
+                                          "name": "priority_fee",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "integer",
+                                            "format": "uint64"
+                                          }
+                                        },
+                                        {
+                                          "name": "public_key",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        {
+                                          "name": "receiver_id",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        {
+                                          "name": "signature",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        {
+                                          "name": "signer_id",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      ],
+                                      "refName": "SignedTransactionDocument"
+                                    }
+                                  }
+                                ],
+                                "refName": "ChunkTransactionWrapper"
+                              }
+                            }
+                          }
+                        ],
+                        "refName": "ChunkDocument"
+                      }
+                    },
+                    {
+                      "name": "receipt_execution_outcomes",
+                      "required": true,
+                      "schema": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "description": "Execution result paired with an optional receipt object.",
+                          "required": [
+                            "execution_outcome",
+                            "receipt"
+                          ],
+                          "additionalProperties": false,
+                          "properties": [
+                            {
+                              "name": "execution_outcome",
+                              "required": true,
+                              "schema": {
+                                "type": "object",
+                                "required": [
+                                  "block_hash",
+                                  "id",
+                                  "outcome",
+                                  "proof"
+                                ],
+                                "additionalProperties": false,
+                                "properties": [
+                                  {
+                                    "name": "block_hash",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  {
+                                    "name": "id",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  {
+                                    "name": "outcome",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "object",
+                                      "required": [
+                                        "executor_id",
+                                        "gas_burnt",
+                                        "logs",
+                                        "metadata",
+                                        "receipt_ids",
+                                        "status",
+                                        "tokens_burnt"
+                                      ],
+                                      "additionalProperties": false,
+                                      "properties": [
+                                        {
+                                          "name": "executor_id",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        {
+                                          "name": "gas_burnt",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "integer",
+                                            "format": "uint64"
+                                          }
+                                        },
+                                        {
+                                          "name": "logs",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "name": "metadata",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "object",
+                                            "additionalProperties": true
+                                          }
+                                        },
+                                        {
+                                          "name": "receipt_ids",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "name": "status",
+                                          "required": true,
+                                          "schema": {
+                                            "oneOf": [
+                                              {
+                                                "type": "object",
+                                                "required": [
+                                                  "SuccessReceiptId"
+                                                ],
+                                                "additionalProperties": false,
+                                                "properties": [
+                                                  {
+                                                    "name": "SuccessReceiptId",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                ],
+                                                "refName": "ExecutionOutcomeStatusSuccessReceiptId"
+                                              },
+                                              {
+                                                "type": "object",
+                                                "required": [
+                                                  "SuccessValue"
+                                                ],
+                                                "additionalProperties": false,
+                                                "properties": [
+                                                  {
+                                                    "name": "SuccessValue",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                ],
+                                                "refName": "ExecutionOutcomeStatusSuccessValue"
+                                              },
+                                              {
+                                                "type": "object",
+                                                "required": [
+                                                  "Failure"
+                                                ],
+                                                "additionalProperties": false,
+                                                "properties": [
+                                                  {
+                                                    "name": "Failure",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "object",
+                                                      "additionalProperties": true
+                                                    }
+                                                  }
+                                                ],
+                                                "refName": "ExecutionOutcomeStatusFailure"
+                                              }
+                                            ],
+                                            "refName": "ExecutionOutcomeStatus"
+                                          }
+                                        },
+                                        {
+                                          "name": "tokens_burnt",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      ],
+                                      "refName": "ExecutionOutcomeSummary"
+                                    }
+                                  },
+                                  {
+                                    "name": "proof",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "additionalProperties": true,
+                                        "refName": "ExecutionProofItem"
+                                      }
+                                    }
+                                  }
+                                ],
+                                "refName": "ExecutionOutcomeDocument"
+                              }
+                            },
+                            {
+                              "name": "receipt",
+                              "required": true,
+                              "schema": {
+                                "type": "object",
+                                "description": "Receipt payload when neardata includes it for this entry.",
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "description": "Receipt object as served by neardata inside a chunk payload.",
+                                    "required": [
+                                      "predecessor_id",
+                                      "priority",
+                                      "receipt",
+                                      "receipt_id",
+                                      "receiver_id"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "predecessor_id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "priority",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "integer",
+                                          "format": "uint64"
+                                        }
+                                      },
+                                      {
+                                        "name": "receipt",
+                                        "required": true,
+                                        "schema": {
+                                          "oneOf": [
+                                            {
+                                              "type": "object",
+                                              "required": [
+                                                "Action"
+                                              ],
+                                              "additionalProperties": false,
+                                              "properties": [
+                                                {
+                                                  "name": "Action",
+                                                  "required": true,
+                                                  "schema": {
+                                                    "type": "object",
+                                                    "required": [
+                                                      "actions",
+                                                      "gas_price",
+                                                      "input_data_ids",
+                                                      "is_promise_yield",
+                                                      "output_data_receivers",
+                                                      "signer_id",
+                                                      "signer_public_key"
+                                                    ],
+                                                    "additionalProperties": false,
+                                                    "properties": [
+                                                      {
+                                                        "name": "actions",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "additionalProperties": true,
+                                                            "refName": "ActionDocument"
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "gas_price",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "input_data_ids",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "string"
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "is_promise_yield",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "output_data_receivers",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "required": [
+                                                              "data_id",
+                                                              "receiver_id"
+                                                            ],
+                                                            "additionalProperties": false,
+                                                            "properties": [
+                                                              {
+                                                                "name": "data_id",
+                                                                "required": true,
+                                                                "schema": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              {
+                                                                "name": "receiver_id",
+                                                                "required": true,
+                                                                "schema": {
+                                                                  "type": "string"
+                                                                }
+                                                              }
+                                                            ],
+                                                            "refName": "OutputDataReceiverDocument"
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "signer_id",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "signer_public_key",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "string"
+                                                        }
+                                                      }
+                                                    ],
+                                                    "refName": "ActionReceiptDocument"
+                                                  }
+                                                }
+                                              ],
+                                              "refName": "ActionReceiptBody"
+                                            },
+                                            {
+                                              "type": "object",
+                                              "required": [
+                                                "Data"
+                                              ],
+                                              "additionalProperties": false,
+                                              "properties": [
+                                                {
+                                                  "name": "Data",
+                                                  "required": true,
+                                                  "schema": {
+                                                    "type": "object",
+                                                    "required": [
+                                                      "data",
+                                                      "data_id",
+                                                      "is_promise_resume"
+                                                    ],
+                                                    "additionalProperties": false,
+                                                    "properties": [
+                                                      {
+                                                        "name": "data",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "data_id",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "is_promise_resume",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "boolean"
+                                                        }
+                                                      }
+                                                    ],
+                                                    "refName": "DataReceiptDocument"
+                                                  }
+                                                }
+                                              ],
+                                              "refName": "DataReceiptBody"
+                                            }
+                                          ],
+                                          "refName": "ReceiptBody"
+                                        }
+                                      },
+                                      {
+                                        "name": "receipt_id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "receiver_id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "ReceiptDocument"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "refName": "OmittedReceiptDocument"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "name": "tx_hash",
+                              "required": false,
+                              "schema": {
+                                "type": "string"
+                              }
+                            }
+                          ],
+                          "refName": "ExecutionWithReceipt"
+                        }
+                      }
+                    },
+                    {
+                      "name": "shard_id",
+                      "required": true,
+                      "schema": {
+                        "type": "integer",
+                        "format": "uint64"
+                      }
+                    },
+                    {
+                      "name": "state_changes",
+                      "required": true,
+                      "schema": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "description": "State change entry returned by neardata for a shard.",
+                          "required": [
+                            "cause",
+                            "change",
+                            "type"
+                          ],
+                          "additionalProperties": false,
+                          "properties": [
+                            {
+                              "name": "cause",
+                              "required": true,
+                              "schema": {
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "required": [
+                                      "tx_hash",
+                                      "type"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "tx_hash",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "type",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "StateChangeCauseTransactionProcessing"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "required": [
+                                      "receipt_hash",
+                                      "type"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "receipt_hash",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "type",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "StateChangeCauseReceiptProcessing"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "required": [
+                                      "receipt_hash",
+                                      "type"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "receipt_hash",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "type",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "StateChangeCauseActionReceiptGasReward"
+                                  }
+                                ],
+                                "refName": "StateChangeCause"
+                              }
+                            },
+                            {
+                              "name": "change",
+                              "required": true,
+                              "schema": {
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "required": [
+                                      "account_id",
+                                      "amount",
+                                      "code_hash",
+                                      "locked",
+                                      "storage_paid_at",
+                                      "storage_usage"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "account_id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "amount",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "code_hash",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "locked",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "storage_paid_at",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "integer",
+                                          "format": "uint64"
+                                        }
+                                      },
+                                      {
+                                        "name": "storage_usage",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "integer",
+                                          "format": "uint64"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "StateChangeValueAccountUpdate"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "required": [
+                                      "access_key",
+                                      "account_id",
+                                      "public_key"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "access_key",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "object",
+                                          "additionalProperties": true
+                                        }
+                                      },
+                                      {
+                                        "name": "account_id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "public_key",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "StateChangeValueAccessKeyUpdate"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "required": [
+                                      "account_id",
+                                      "key_base64",
+                                      "value_base64"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "account_id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "key_base64",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "value_base64",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "StateChangeValueDataUpdate"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "required": [
+                                      "account_id",
+                                      "key_base64"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "account_id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "key_base64",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "StateChangeValueDataDeletion"
+                                  }
+                                ],
+                                "refName": "StateChangeValue"
+                              }
+                            },
+                            {
+                              "name": "type",
+                              "required": true,
+                              "schema": {
+                                "type": "string"
+                              }
+                            }
+                          ],
+                          "refName": "StateChangeItem"
+                        }
+                      }
+                    }
+                  ],
+                  "refName": "ShardDocument"
+                }
+              }
+            }
+          ],
+          "refName": "BlockDocument"
         },
         "status": "200"
       },
@@ -21915,8 +29919,1804 @@
         "mediaType": "application/json",
         "schema": {
           "type": "object",
-          "description": "Full block document as served by neardata, including `block` and `shards`.",
-          "additionalProperties": true
+          "description": "Full block document as served by neardata, including the block envelope and per-shard payloads.",
+          "required": [
+            "block",
+            "shards"
+          ],
+          "additionalProperties": false,
+          "properties": [
+            {
+              "name": "block",
+              "required": true,
+              "schema": {
+                "type": "object",
+                "description": "Block-level payload returned by neardata.",
+                "required": [
+                  "author",
+                  "chunks",
+                  "header"
+                ],
+                "additionalProperties": false,
+                "properties": [
+                  {
+                    "name": "author",
+                    "required": true,
+                    "schema": {
+                      "type": "string",
+                      "description": "Block producer account ID."
+                    }
+                  },
+                  {
+                    "name": "chunks",
+                    "required": true,
+                    "schema": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "description": "Chunk header object as served by neardata.",
+                        "additionalProperties": true,
+                        "properties": [
+                          {
+                            "name": "chunk_hash",
+                            "required": false,
+                            "schema": {
+                              "type": "string"
+                            }
+                          },
+                          {
+                            "name": "gas_limit",
+                            "required": false,
+                            "schema": {
+                              "type": "integer"
+                            }
+                          },
+                          {
+                            "name": "gas_used",
+                            "required": false,
+                            "schema": {
+                              "type": "integer"
+                            }
+                          },
+                          {
+                            "name": "height_created",
+                            "required": false,
+                            "schema": {
+                              "type": "integer",
+                              "format": "uint64"
+                            }
+                          },
+                          {
+                            "name": "height_included",
+                            "required": false,
+                            "schema": {
+                              "type": "integer",
+                              "format": "uint64"
+                            }
+                          },
+                          {
+                            "name": "outcome_root",
+                            "required": false,
+                            "schema": {
+                              "type": "string"
+                            }
+                          },
+                          {
+                            "name": "outgoing_receipts_root",
+                            "required": false,
+                            "schema": {
+                              "type": "string"
+                            }
+                          },
+                          {
+                            "name": "prev_block_hash",
+                            "required": false,
+                            "schema": {
+                              "type": "string"
+                            }
+                          },
+                          {
+                            "name": "shard_id",
+                            "required": false,
+                            "schema": {
+                              "type": "integer",
+                              "format": "uint64"
+                            }
+                          },
+                          {
+                            "name": "tx_root",
+                            "required": false,
+                            "schema": {
+                              "type": "string"
+                            }
+                          }
+                        ],
+                        "refName": "ChunkHeader"
+                      }
+                    }
+                  },
+                  {
+                    "name": "header",
+                    "required": true,
+                    "schema": {
+                      "type": "object",
+                      "description": "Block header object as served by neardata.",
+                      "additionalProperties": true,
+                      "properties": [
+                        {
+                          "name": "chunks_included",
+                          "required": false,
+                          "schema": {
+                            "type": "integer",
+                            "format": "uint64"
+                          }
+                        },
+                        {
+                          "name": "epoch_id",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "name": "gas_price",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "name": "hash",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "name": "height",
+                          "required": false,
+                          "schema": {
+                            "type": "integer",
+                            "format": "uint64"
+                          }
+                        },
+                        {
+                          "name": "next_epoch_id",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "name": "prev_hash",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "name": "prev_height",
+                          "required": false,
+                          "schema": {
+                            "type": "integer",
+                            "format": "uint64"
+                          }
+                        },
+                        {
+                          "name": "timestamp",
+                          "required": false,
+                          "schema": {
+                            "type": "integer"
+                          }
+                        },
+                        {
+                          "name": "timestamp_nanosec",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "name": "total_supply",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        }
+                      ],
+                      "refName": "BlockHeader"
+                    }
+                  }
+                ],
+                "refName": "BlockEnvelope"
+              }
+            },
+            {
+              "name": "shards",
+              "required": true,
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "description": "Per-shard payload returned by neardata for a block.",
+                  "required": [
+                    "chunk",
+                    "receipt_execution_outcomes",
+                    "shard_id",
+                    "state_changes"
+                  ],
+                  "additionalProperties": false,
+                  "properties": [
+                    {
+                      "name": "chunk",
+                      "required": true,
+                      "schema": {
+                        "type": "object",
+                        "description": "Chunk payload returned by neardata for a single shard in a selected block.",
+                        "required": [
+                          "author",
+                          "header",
+                          "receipts",
+                          "transactions"
+                        ],
+                        "additionalProperties": false,
+                        "properties": [
+                          {
+                            "name": "author",
+                            "required": true,
+                            "schema": {
+                              "type": "string",
+                              "description": "Chunk producer account ID."
+                            }
+                          },
+                          {
+                            "name": "header",
+                            "required": true,
+                            "schema": {
+                              "type": "object",
+                              "description": "Chunk header object as served by neardata.",
+                              "additionalProperties": true,
+                              "properties": [
+                                {
+                                  "name": "chunk_hash",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "string"
+                                  }
+                                },
+                                {
+                                  "name": "gas_limit",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "integer"
+                                  }
+                                },
+                                {
+                                  "name": "gas_used",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "integer"
+                                  }
+                                },
+                                {
+                                  "name": "height_created",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "integer",
+                                    "format": "uint64"
+                                  }
+                                },
+                                {
+                                  "name": "height_included",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "integer",
+                                    "format": "uint64"
+                                  }
+                                },
+                                {
+                                  "name": "outcome_root",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "string"
+                                  }
+                                },
+                                {
+                                  "name": "outgoing_receipts_root",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "string"
+                                  }
+                                },
+                                {
+                                  "name": "prev_block_hash",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "string"
+                                  }
+                                },
+                                {
+                                  "name": "shard_id",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "integer",
+                                    "format": "uint64"
+                                  }
+                                },
+                                {
+                                  "name": "tx_root",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "string"
+                                  }
+                                }
+                              ],
+                              "refName": "ChunkHeader"
+                            }
+                          },
+                          {
+                            "name": "receipts",
+                            "required": true,
+                            "schema": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "description": "Receipt object as served by neardata inside a chunk payload.",
+                                "required": [
+                                  "predecessor_id",
+                                  "priority",
+                                  "receipt",
+                                  "receipt_id",
+                                  "receiver_id"
+                                ],
+                                "additionalProperties": false,
+                                "properties": [
+                                  {
+                                    "name": "predecessor_id",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  {
+                                    "name": "priority",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "integer",
+                                      "format": "uint64"
+                                    }
+                                  },
+                                  {
+                                    "name": "receipt",
+                                    "required": true,
+                                    "schema": {
+                                      "oneOf": [
+                                        {
+                                          "type": "object",
+                                          "required": [
+                                            "Action"
+                                          ],
+                                          "additionalProperties": false,
+                                          "properties": [
+                                            {
+                                              "name": "Action",
+                                              "required": true,
+                                              "schema": {
+                                                "type": "object",
+                                                "required": [
+                                                  "actions",
+                                                  "gas_price",
+                                                  "input_data_ids",
+                                                  "is_promise_yield",
+                                                  "output_data_receivers",
+                                                  "signer_id",
+                                                  "signer_public_key"
+                                                ],
+                                                "additionalProperties": false,
+                                                "properties": [
+                                                  {
+                                                    "name": "actions",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "object",
+                                                        "additionalProperties": true,
+                                                        "refName": "ActionDocument"
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "gas_price",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "input_data_ids",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "is_promise_yield",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "output_data_receivers",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "object",
+                                                        "required": [
+                                                          "data_id",
+                                                          "receiver_id"
+                                                        ],
+                                                        "additionalProperties": false,
+                                                        "properties": [
+                                                          {
+                                                            "name": "data_id",
+                                                            "required": true,
+                                                            "schema": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          {
+                                                            "name": "receiver_id",
+                                                            "required": true,
+                                                            "schema": {
+                                                              "type": "string"
+                                                            }
+                                                          }
+                                                        ],
+                                                        "refName": "OutputDataReceiverDocument"
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "signer_id",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "signer_public_key",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                ],
+                                                "refName": "ActionReceiptDocument"
+                                              }
+                                            }
+                                          ],
+                                          "refName": "ActionReceiptBody"
+                                        },
+                                        {
+                                          "type": "object",
+                                          "required": [
+                                            "Data"
+                                          ],
+                                          "additionalProperties": false,
+                                          "properties": [
+                                            {
+                                              "name": "Data",
+                                              "required": true,
+                                              "schema": {
+                                                "type": "object",
+                                                "required": [
+                                                  "data",
+                                                  "data_id",
+                                                  "is_promise_resume"
+                                                ],
+                                                "additionalProperties": false,
+                                                "properties": [
+                                                  {
+                                                    "name": "data",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "data_id",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "is_promise_resume",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "boolean"
+                                                    }
+                                                  }
+                                                ],
+                                                "refName": "DataReceiptDocument"
+                                              }
+                                            }
+                                          ],
+                                          "refName": "DataReceiptBody"
+                                        }
+                                      ],
+                                      "refName": "ReceiptBody"
+                                    }
+                                  },
+                                  {
+                                    "name": "receipt_id",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  {
+                                    "name": "receiver_id",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "string"
+                                    }
+                                  }
+                                ],
+                                "refName": "ReceiptDocument"
+                              }
+                            }
+                          },
+                          {
+                            "name": "transactions",
+                            "required": true,
+                            "schema": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "description": "Transaction entry returned inside a neardata chunk.",
+                                "required": [
+                                  "outcome",
+                                  "transaction"
+                                ],
+                                "additionalProperties": false,
+                                "properties": [
+                                  {
+                                    "name": "outcome",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "object",
+                                      "description": "Execution result paired with an optional receipt object.",
+                                      "required": [
+                                        "execution_outcome",
+                                        "receipt"
+                                      ],
+                                      "additionalProperties": false,
+                                      "properties": [
+                                        {
+                                          "name": "execution_outcome",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "object",
+                                            "required": [
+                                              "block_hash",
+                                              "id",
+                                              "outcome",
+                                              "proof"
+                                            ],
+                                            "additionalProperties": false,
+                                            "properties": [
+                                              {
+                                                "name": "block_hash",
+                                                "required": true,
+                                                "schema": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              {
+                                                "name": "id",
+                                                "required": true,
+                                                "schema": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              {
+                                                "name": "outcome",
+                                                "required": true,
+                                                "schema": {
+                                                  "type": "object",
+                                                  "required": [
+                                                    "executor_id",
+                                                    "gas_burnt",
+                                                    "logs",
+                                                    "metadata",
+                                                    "receipt_ids",
+                                                    "status",
+                                                    "tokens_burnt"
+                                                  ],
+                                                  "additionalProperties": false,
+                                                  "properties": [
+                                                    {
+                                                      "name": "executor_id",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "gas_burnt",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "integer",
+                                                        "format": "uint64"
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "logs",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "metadata",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "object",
+                                                        "additionalProperties": true
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "receipt_ids",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "status",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "oneOf": [
+                                                          {
+                                                            "type": "object",
+                                                            "required": [
+                                                              "SuccessReceiptId"
+                                                            ],
+                                                            "additionalProperties": false,
+                                                            "properties": [
+                                                              {
+                                                                "name": "SuccessReceiptId",
+                                                                "required": true,
+                                                                "schema": {
+                                                                  "type": "string"
+                                                                }
+                                                              }
+                                                            ],
+                                                            "refName": "ExecutionOutcomeStatusSuccessReceiptId"
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "required": [
+                                                              "SuccessValue"
+                                                            ],
+                                                            "additionalProperties": false,
+                                                            "properties": [
+                                                              {
+                                                                "name": "SuccessValue",
+                                                                "required": true,
+                                                                "schema": {
+                                                                  "type": "string"
+                                                                }
+                                                              }
+                                                            ],
+                                                            "refName": "ExecutionOutcomeStatusSuccessValue"
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "required": [
+                                                              "Failure"
+                                                            ],
+                                                            "additionalProperties": false,
+                                                            "properties": [
+                                                              {
+                                                                "name": "Failure",
+                                                                "required": true,
+                                                                "schema": {
+                                                                  "type": "object",
+                                                                  "additionalProperties": true
+                                                                }
+                                                              }
+                                                            ],
+                                                            "refName": "ExecutionOutcomeStatusFailure"
+                                                          }
+                                                        ],
+                                                        "refName": "ExecutionOutcomeStatus"
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "tokens_burnt",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  ],
+                                                  "refName": "ExecutionOutcomeSummary"
+                                                }
+                                              },
+                                              {
+                                                "name": "proof",
+                                                "required": true,
+                                                "schema": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "object",
+                                                    "additionalProperties": true,
+                                                    "refName": "ExecutionProofItem"
+                                                  }
+                                                }
+                                              }
+                                            ],
+                                            "refName": "ExecutionOutcomeDocument"
+                                          }
+                                        },
+                                        {
+                                          "name": "receipt",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "object",
+                                            "description": "Receipt payload when neardata includes it for this entry.",
+                                            "oneOf": [
+                                              {
+                                                "type": "object",
+                                                "description": "Receipt object as served by neardata inside a chunk payload.",
+                                                "required": [
+                                                  "predecessor_id",
+                                                  "priority",
+                                                  "receipt",
+                                                  "receipt_id",
+                                                  "receiver_id"
+                                                ],
+                                                "additionalProperties": false,
+                                                "properties": [
+                                                  {
+                                                    "name": "predecessor_id",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "priority",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "integer",
+                                                      "format": "uint64"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "receipt",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "oneOf": [
+                                                        {
+                                                          "type": "object",
+                                                          "required": [
+                                                            "Action"
+                                                          ],
+                                                          "additionalProperties": false,
+                                                          "properties": [
+                                                            {
+                                                              "name": "Action",
+                                                              "required": true,
+                                                              "schema": {
+                                                                "type": "object",
+                                                                "required": [
+                                                                  "actions",
+                                                                  "gas_price",
+                                                                  "input_data_ids",
+                                                                  "is_promise_yield",
+                                                                  "output_data_receivers",
+                                                                  "signer_id",
+                                                                  "signer_public_key"
+                                                                ],
+                                                                "additionalProperties": false,
+                                                                "properties": [
+                                                                  {
+                                                                    "name": "actions",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "array",
+                                                                      "items": {
+                                                                        "type": "object",
+                                                                        "additionalProperties": true,
+                                                                        "refName": "ActionDocument"
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "gas_price",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "input_data_ids",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "array",
+                                                                      "items": {
+                                                                        "type": "string"
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "is_promise_yield",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "boolean"
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "output_data_receivers",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "array",
+                                                                      "items": {
+                                                                        "type": "object",
+                                                                        "required": [
+                                                                          "data_id",
+                                                                          "receiver_id"
+                                                                        ],
+                                                                        "additionalProperties": false,
+                                                                        "properties": [
+                                                                          {
+                                                                            "name": "data_id",
+                                                                            "required": true,
+                                                                            "schema": {
+                                                                              "type": "string"
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "name": "receiver_id",
+                                                                            "required": true,
+                                                                            "schema": {
+                                                                              "type": "string"
+                                                                            }
+                                                                          }
+                                                                        ],
+                                                                        "refName": "OutputDataReceiverDocument"
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "signer_id",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "signer_public_key",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  }
+                                                                ],
+                                                                "refName": "ActionReceiptDocument"
+                                                              }
+                                                            }
+                                                          ],
+                                                          "refName": "ActionReceiptBody"
+                                                        },
+                                                        {
+                                                          "type": "object",
+                                                          "required": [
+                                                            "Data"
+                                                          ],
+                                                          "additionalProperties": false,
+                                                          "properties": [
+                                                            {
+                                                              "name": "Data",
+                                                              "required": true,
+                                                              "schema": {
+                                                                "type": "object",
+                                                                "required": [
+                                                                  "data",
+                                                                  "data_id",
+                                                                  "is_promise_resume"
+                                                                ],
+                                                                "additionalProperties": false,
+                                                                "properties": [
+                                                                  {
+                                                                    "name": "data",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "data_id",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "is_promise_resume",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "boolean"
+                                                                    }
+                                                                  }
+                                                                ],
+                                                                "refName": "DataReceiptDocument"
+                                                              }
+                                                            }
+                                                          ],
+                                                          "refName": "DataReceiptBody"
+                                                        }
+                                                      ],
+                                                      "refName": "ReceiptBody"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "receipt_id",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "receiver_id",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                ],
+                                                "refName": "ReceiptDocument"
+                                              },
+                                              {
+                                                "type": "object",
+                                                "additionalProperties": false,
+                                                "refName": "OmittedReceiptDocument"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "name": "tx_hash",
+                                          "required": false,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      ],
+                                      "refName": "ExecutionWithReceipt"
+                                    }
+                                  },
+                                  {
+                                    "name": "transaction",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "object",
+                                      "required": [
+                                        "actions",
+                                        "hash",
+                                        "nonce",
+                                        "priority_fee",
+                                        "public_key",
+                                        "receiver_id",
+                                        "signature",
+                                        "signer_id"
+                                      ],
+                                      "additionalProperties": false,
+                                      "properties": [
+                                        {
+                                          "name": "actions",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "additionalProperties": true,
+                                              "refName": "ActionDocument"
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "name": "hash",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        {
+                                          "name": "nonce",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "integer",
+                                            "format": "uint64"
+                                          }
+                                        },
+                                        {
+                                          "name": "priority_fee",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "integer",
+                                            "format": "uint64"
+                                          }
+                                        },
+                                        {
+                                          "name": "public_key",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        {
+                                          "name": "receiver_id",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        {
+                                          "name": "signature",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        {
+                                          "name": "signer_id",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      ],
+                                      "refName": "SignedTransactionDocument"
+                                    }
+                                  }
+                                ],
+                                "refName": "ChunkTransactionWrapper"
+                              }
+                            }
+                          }
+                        ],
+                        "refName": "ChunkDocument"
+                      }
+                    },
+                    {
+                      "name": "receipt_execution_outcomes",
+                      "required": true,
+                      "schema": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "description": "Execution result paired with an optional receipt object.",
+                          "required": [
+                            "execution_outcome",
+                            "receipt"
+                          ],
+                          "additionalProperties": false,
+                          "properties": [
+                            {
+                              "name": "execution_outcome",
+                              "required": true,
+                              "schema": {
+                                "type": "object",
+                                "required": [
+                                  "block_hash",
+                                  "id",
+                                  "outcome",
+                                  "proof"
+                                ],
+                                "additionalProperties": false,
+                                "properties": [
+                                  {
+                                    "name": "block_hash",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  {
+                                    "name": "id",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  {
+                                    "name": "outcome",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "object",
+                                      "required": [
+                                        "executor_id",
+                                        "gas_burnt",
+                                        "logs",
+                                        "metadata",
+                                        "receipt_ids",
+                                        "status",
+                                        "tokens_burnt"
+                                      ],
+                                      "additionalProperties": false,
+                                      "properties": [
+                                        {
+                                          "name": "executor_id",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        {
+                                          "name": "gas_burnt",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "integer",
+                                            "format": "uint64"
+                                          }
+                                        },
+                                        {
+                                          "name": "logs",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "name": "metadata",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "object",
+                                            "additionalProperties": true
+                                          }
+                                        },
+                                        {
+                                          "name": "receipt_ids",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "name": "status",
+                                          "required": true,
+                                          "schema": {
+                                            "oneOf": [
+                                              {
+                                                "type": "object",
+                                                "required": [
+                                                  "SuccessReceiptId"
+                                                ],
+                                                "additionalProperties": false,
+                                                "properties": [
+                                                  {
+                                                    "name": "SuccessReceiptId",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                ],
+                                                "refName": "ExecutionOutcomeStatusSuccessReceiptId"
+                                              },
+                                              {
+                                                "type": "object",
+                                                "required": [
+                                                  "SuccessValue"
+                                                ],
+                                                "additionalProperties": false,
+                                                "properties": [
+                                                  {
+                                                    "name": "SuccessValue",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                ],
+                                                "refName": "ExecutionOutcomeStatusSuccessValue"
+                                              },
+                                              {
+                                                "type": "object",
+                                                "required": [
+                                                  "Failure"
+                                                ],
+                                                "additionalProperties": false,
+                                                "properties": [
+                                                  {
+                                                    "name": "Failure",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "object",
+                                                      "additionalProperties": true
+                                                    }
+                                                  }
+                                                ],
+                                                "refName": "ExecutionOutcomeStatusFailure"
+                                              }
+                                            ],
+                                            "refName": "ExecutionOutcomeStatus"
+                                          }
+                                        },
+                                        {
+                                          "name": "tokens_burnt",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      ],
+                                      "refName": "ExecutionOutcomeSummary"
+                                    }
+                                  },
+                                  {
+                                    "name": "proof",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "additionalProperties": true,
+                                        "refName": "ExecutionProofItem"
+                                      }
+                                    }
+                                  }
+                                ],
+                                "refName": "ExecutionOutcomeDocument"
+                              }
+                            },
+                            {
+                              "name": "receipt",
+                              "required": true,
+                              "schema": {
+                                "type": "object",
+                                "description": "Receipt payload when neardata includes it for this entry.",
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "description": "Receipt object as served by neardata inside a chunk payload.",
+                                    "required": [
+                                      "predecessor_id",
+                                      "priority",
+                                      "receipt",
+                                      "receipt_id",
+                                      "receiver_id"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "predecessor_id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "priority",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "integer",
+                                          "format": "uint64"
+                                        }
+                                      },
+                                      {
+                                        "name": "receipt",
+                                        "required": true,
+                                        "schema": {
+                                          "oneOf": [
+                                            {
+                                              "type": "object",
+                                              "required": [
+                                                "Action"
+                                              ],
+                                              "additionalProperties": false,
+                                              "properties": [
+                                                {
+                                                  "name": "Action",
+                                                  "required": true,
+                                                  "schema": {
+                                                    "type": "object",
+                                                    "required": [
+                                                      "actions",
+                                                      "gas_price",
+                                                      "input_data_ids",
+                                                      "is_promise_yield",
+                                                      "output_data_receivers",
+                                                      "signer_id",
+                                                      "signer_public_key"
+                                                    ],
+                                                    "additionalProperties": false,
+                                                    "properties": [
+                                                      {
+                                                        "name": "actions",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "additionalProperties": true,
+                                                            "refName": "ActionDocument"
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "gas_price",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "input_data_ids",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "string"
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "is_promise_yield",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "output_data_receivers",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "required": [
+                                                              "data_id",
+                                                              "receiver_id"
+                                                            ],
+                                                            "additionalProperties": false,
+                                                            "properties": [
+                                                              {
+                                                                "name": "data_id",
+                                                                "required": true,
+                                                                "schema": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              {
+                                                                "name": "receiver_id",
+                                                                "required": true,
+                                                                "schema": {
+                                                                  "type": "string"
+                                                                }
+                                                              }
+                                                            ],
+                                                            "refName": "OutputDataReceiverDocument"
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "signer_id",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "signer_public_key",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "string"
+                                                        }
+                                                      }
+                                                    ],
+                                                    "refName": "ActionReceiptDocument"
+                                                  }
+                                                }
+                                              ],
+                                              "refName": "ActionReceiptBody"
+                                            },
+                                            {
+                                              "type": "object",
+                                              "required": [
+                                                "Data"
+                                              ],
+                                              "additionalProperties": false,
+                                              "properties": [
+                                                {
+                                                  "name": "Data",
+                                                  "required": true,
+                                                  "schema": {
+                                                    "type": "object",
+                                                    "required": [
+                                                      "data",
+                                                      "data_id",
+                                                      "is_promise_resume"
+                                                    ],
+                                                    "additionalProperties": false,
+                                                    "properties": [
+                                                      {
+                                                        "name": "data",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "data_id",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "is_promise_resume",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "boolean"
+                                                        }
+                                                      }
+                                                    ],
+                                                    "refName": "DataReceiptDocument"
+                                                  }
+                                                }
+                                              ],
+                                              "refName": "DataReceiptBody"
+                                            }
+                                          ],
+                                          "refName": "ReceiptBody"
+                                        }
+                                      },
+                                      {
+                                        "name": "receipt_id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "receiver_id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "ReceiptDocument"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "refName": "OmittedReceiptDocument"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "name": "tx_hash",
+                              "required": false,
+                              "schema": {
+                                "type": "string"
+                              }
+                            }
+                          ],
+                          "refName": "ExecutionWithReceipt"
+                        }
+                      }
+                    },
+                    {
+                      "name": "shard_id",
+                      "required": true,
+                      "schema": {
+                        "type": "integer",
+                        "format": "uint64"
+                      }
+                    },
+                    {
+                      "name": "state_changes",
+                      "required": true,
+                      "schema": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "description": "State change entry returned by neardata for a shard.",
+                          "required": [
+                            "cause",
+                            "change",
+                            "type"
+                          ],
+                          "additionalProperties": false,
+                          "properties": [
+                            {
+                              "name": "cause",
+                              "required": true,
+                              "schema": {
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "required": [
+                                      "tx_hash",
+                                      "type"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "tx_hash",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "type",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "StateChangeCauseTransactionProcessing"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "required": [
+                                      "receipt_hash",
+                                      "type"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "receipt_hash",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "type",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "StateChangeCauseReceiptProcessing"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "required": [
+                                      "receipt_hash",
+                                      "type"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "receipt_hash",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "type",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "StateChangeCauseActionReceiptGasReward"
+                                  }
+                                ],
+                                "refName": "StateChangeCause"
+                              }
+                            },
+                            {
+                              "name": "change",
+                              "required": true,
+                              "schema": {
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "required": [
+                                      "account_id",
+                                      "amount",
+                                      "code_hash",
+                                      "locked",
+                                      "storage_paid_at",
+                                      "storage_usage"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "account_id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "amount",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "code_hash",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "locked",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "storage_paid_at",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "integer",
+                                          "format": "uint64"
+                                        }
+                                      },
+                                      {
+                                        "name": "storage_usage",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "integer",
+                                          "format": "uint64"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "StateChangeValueAccountUpdate"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "required": [
+                                      "access_key",
+                                      "account_id",
+                                      "public_key"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "access_key",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "object",
+                                          "additionalProperties": true
+                                        }
+                                      },
+                                      {
+                                        "name": "account_id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "public_key",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "StateChangeValueAccessKeyUpdate"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "required": [
+                                      "account_id",
+                                      "key_base64",
+                                      "value_base64"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "account_id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "key_base64",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "value_base64",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "StateChangeValueDataUpdate"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "required": [
+                                      "account_id",
+                                      "key_base64"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "account_id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "key_base64",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "StateChangeValueDataDeletion"
+                                  }
+                                ],
+                                "refName": "StateChangeValue"
+                              }
+                            },
+                            {
+                              "name": "type",
+                              "required": true,
+                              "schema": {
+                                "type": "string"
+                              }
+                            }
+                          ],
+                          "refName": "StateChangeItem"
+                        }
+                      }
+                    }
+                  ],
+                  "refName": "ShardDocument"
+                }
+              }
+            }
+          ],
+          "refName": "BlockDocument"
         },
         "status": "200"
       },
@@ -22044,8 +31844,1804 @@
         "mediaType": "application/json",
         "schema": {
           "type": "object",
-          "description": "Full block document as served by neardata, including `block` and `shards`.",
-          "additionalProperties": true
+          "description": "Full block document as served by neardata, including the block envelope and per-shard payloads.",
+          "required": [
+            "block",
+            "shards"
+          ],
+          "additionalProperties": false,
+          "properties": [
+            {
+              "name": "block",
+              "required": true,
+              "schema": {
+                "type": "object",
+                "description": "Block-level payload returned by neardata.",
+                "required": [
+                  "author",
+                  "chunks",
+                  "header"
+                ],
+                "additionalProperties": false,
+                "properties": [
+                  {
+                    "name": "author",
+                    "required": true,
+                    "schema": {
+                      "type": "string",
+                      "description": "Block producer account ID."
+                    }
+                  },
+                  {
+                    "name": "chunks",
+                    "required": true,
+                    "schema": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "description": "Chunk header object as served by neardata.",
+                        "additionalProperties": true,
+                        "properties": [
+                          {
+                            "name": "chunk_hash",
+                            "required": false,
+                            "schema": {
+                              "type": "string"
+                            }
+                          },
+                          {
+                            "name": "gas_limit",
+                            "required": false,
+                            "schema": {
+                              "type": "integer"
+                            }
+                          },
+                          {
+                            "name": "gas_used",
+                            "required": false,
+                            "schema": {
+                              "type": "integer"
+                            }
+                          },
+                          {
+                            "name": "height_created",
+                            "required": false,
+                            "schema": {
+                              "type": "integer",
+                              "format": "uint64"
+                            }
+                          },
+                          {
+                            "name": "height_included",
+                            "required": false,
+                            "schema": {
+                              "type": "integer",
+                              "format": "uint64"
+                            }
+                          },
+                          {
+                            "name": "outcome_root",
+                            "required": false,
+                            "schema": {
+                              "type": "string"
+                            }
+                          },
+                          {
+                            "name": "outgoing_receipts_root",
+                            "required": false,
+                            "schema": {
+                              "type": "string"
+                            }
+                          },
+                          {
+                            "name": "prev_block_hash",
+                            "required": false,
+                            "schema": {
+                              "type": "string"
+                            }
+                          },
+                          {
+                            "name": "shard_id",
+                            "required": false,
+                            "schema": {
+                              "type": "integer",
+                              "format": "uint64"
+                            }
+                          },
+                          {
+                            "name": "tx_root",
+                            "required": false,
+                            "schema": {
+                              "type": "string"
+                            }
+                          }
+                        ],
+                        "refName": "ChunkHeader"
+                      }
+                    }
+                  },
+                  {
+                    "name": "header",
+                    "required": true,
+                    "schema": {
+                      "type": "object",
+                      "description": "Block header object as served by neardata.",
+                      "additionalProperties": true,
+                      "properties": [
+                        {
+                          "name": "chunks_included",
+                          "required": false,
+                          "schema": {
+                            "type": "integer",
+                            "format": "uint64"
+                          }
+                        },
+                        {
+                          "name": "epoch_id",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "name": "gas_price",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "name": "hash",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "name": "height",
+                          "required": false,
+                          "schema": {
+                            "type": "integer",
+                            "format": "uint64"
+                          }
+                        },
+                        {
+                          "name": "next_epoch_id",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "name": "prev_hash",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "name": "prev_height",
+                          "required": false,
+                          "schema": {
+                            "type": "integer",
+                            "format": "uint64"
+                          }
+                        },
+                        {
+                          "name": "timestamp",
+                          "required": false,
+                          "schema": {
+                            "type": "integer"
+                          }
+                        },
+                        {
+                          "name": "timestamp_nanosec",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "name": "total_supply",
+                          "required": false,
+                          "schema": {
+                            "type": "string"
+                          }
+                        }
+                      ],
+                      "refName": "BlockHeader"
+                    }
+                  }
+                ],
+                "refName": "BlockEnvelope"
+              }
+            },
+            {
+              "name": "shards",
+              "required": true,
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "description": "Per-shard payload returned by neardata for a block.",
+                  "required": [
+                    "chunk",
+                    "receipt_execution_outcomes",
+                    "shard_id",
+                    "state_changes"
+                  ],
+                  "additionalProperties": false,
+                  "properties": [
+                    {
+                      "name": "chunk",
+                      "required": true,
+                      "schema": {
+                        "type": "object",
+                        "description": "Chunk payload returned by neardata for a single shard in a selected block.",
+                        "required": [
+                          "author",
+                          "header",
+                          "receipts",
+                          "transactions"
+                        ],
+                        "additionalProperties": false,
+                        "properties": [
+                          {
+                            "name": "author",
+                            "required": true,
+                            "schema": {
+                              "type": "string",
+                              "description": "Chunk producer account ID."
+                            }
+                          },
+                          {
+                            "name": "header",
+                            "required": true,
+                            "schema": {
+                              "type": "object",
+                              "description": "Chunk header object as served by neardata.",
+                              "additionalProperties": true,
+                              "properties": [
+                                {
+                                  "name": "chunk_hash",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "string"
+                                  }
+                                },
+                                {
+                                  "name": "gas_limit",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "integer"
+                                  }
+                                },
+                                {
+                                  "name": "gas_used",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "integer"
+                                  }
+                                },
+                                {
+                                  "name": "height_created",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "integer",
+                                    "format": "uint64"
+                                  }
+                                },
+                                {
+                                  "name": "height_included",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "integer",
+                                    "format": "uint64"
+                                  }
+                                },
+                                {
+                                  "name": "outcome_root",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "string"
+                                  }
+                                },
+                                {
+                                  "name": "outgoing_receipts_root",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "string"
+                                  }
+                                },
+                                {
+                                  "name": "prev_block_hash",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "string"
+                                  }
+                                },
+                                {
+                                  "name": "shard_id",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "integer",
+                                    "format": "uint64"
+                                  }
+                                },
+                                {
+                                  "name": "tx_root",
+                                  "required": false,
+                                  "schema": {
+                                    "type": "string"
+                                  }
+                                }
+                              ],
+                              "refName": "ChunkHeader"
+                            }
+                          },
+                          {
+                            "name": "receipts",
+                            "required": true,
+                            "schema": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "description": "Receipt object as served by neardata inside a chunk payload.",
+                                "required": [
+                                  "predecessor_id",
+                                  "priority",
+                                  "receipt",
+                                  "receipt_id",
+                                  "receiver_id"
+                                ],
+                                "additionalProperties": false,
+                                "properties": [
+                                  {
+                                    "name": "predecessor_id",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  {
+                                    "name": "priority",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "integer",
+                                      "format": "uint64"
+                                    }
+                                  },
+                                  {
+                                    "name": "receipt",
+                                    "required": true,
+                                    "schema": {
+                                      "oneOf": [
+                                        {
+                                          "type": "object",
+                                          "required": [
+                                            "Action"
+                                          ],
+                                          "additionalProperties": false,
+                                          "properties": [
+                                            {
+                                              "name": "Action",
+                                              "required": true,
+                                              "schema": {
+                                                "type": "object",
+                                                "required": [
+                                                  "actions",
+                                                  "gas_price",
+                                                  "input_data_ids",
+                                                  "is_promise_yield",
+                                                  "output_data_receivers",
+                                                  "signer_id",
+                                                  "signer_public_key"
+                                                ],
+                                                "additionalProperties": false,
+                                                "properties": [
+                                                  {
+                                                    "name": "actions",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "object",
+                                                        "additionalProperties": true,
+                                                        "refName": "ActionDocument"
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "gas_price",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "input_data_ids",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "is_promise_yield",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "output_data_receivers",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "object",
+                                                        "required": [
+                                                          "data_id",
+                                                          "receiver_id"
+                                                        ],
+                                                        "additionalProperties": false,
+                                                        "properties": [
+                                                          {
+                                                            "name": "data_id",
+                                                            "required": true,
+                                                            "schema": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          {
+                                                            "name": "receiver_id",
+                                                            "required": true,
+                                                            "schema": {
+                                                              "type": "string"
+                                                            }
+                                                          }
+                                                        ],
+                                                        "refName": "OutputDataReceiverDocument"
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "signer_id",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "signer_public_key",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                ],
+                                                "refName": "ActionReceiptDocument"
+                                              }
+                                            }
+                                          ],
+                                          "refName": "ActionReceiptBody"
+                                        },
+                                        {
+                                          "type": "object",
+                                          "required": [
+                                            "Data"
+                                          ],
+                                          "additionalProperties": false,
+                                          "properties": [
+                                            {
+                                              "name": "Data",
+                                              "required": true,
+                                              "schema": {
+                                                "type": "object",
+                                                "required": [
+                                                  "data",
+                                                  "data_id",
+                                                  "is_promise_resume"
+                                                ],
+                                                "additionalProperties": false,
+                                                "properties": [
+                                                  {
+                                                    "name": "data",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "data_id",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "is_promise_resume",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "boolean"
+                                                    }
+                                                  }
+                                                ],
+                                                "refName": "DataReceiptDocument"
+                                              }
+                                            }
+                                          ],
+                                          "refName": "DataReceiptBody"
+                                        }
+                                      ],
+                                      "refName": "ReceiptBody"
+                                    }
+                                  },
+                                  {
+                                    "name": "receipt_id",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  {
+                                    "name": "receiver_id",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "string"
+                                    }
+                                  }
+                                ],
+                                "refName": "ReceiptDocument"
+                              }
+                            }
+                          },
+                          {
+                            "name": "transactions",
+                            "required": true,
+                            "schema": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "description": "Transaction entry returned inside a neardata chunk.",
+                                "required": [
+                                  "outcome",
+                                  "transaction"
+                                ],
+                                "additionalProperties": false,
+                                "properties": [
+                                  {
+                                    "name": "outcome",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "object",
+                                      "description": "Execution result paired with an optional receipt object.",
+                                      "required": [
+                                        "execution_outcome",
+                                        "receipt"
+                                      ],
+                                      "additionalProperties": false,
+                                      "properties": [
+                                        {
+                                          "name": "execution_outcome",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "object",
+                                            "required": [
+                                              "block_hash",
+                                              "id",
+                                              "outcome",
+                                              "proof"
+                                            ],
+                                            "additionalProperties": false,
+                                            "properties": [
+                                              {
+                                                "name": "block_hash",
+                                                "required": true,
+                                                "schema": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              {
+                                                "name": "id",
+                                                "required": true,
+                                                "schema": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              {
+                                                "name": "outcome",
+                                                "required": true,
+                                                "schema": {
+                                                  "type": "object",
+                                                  "required": [
+                                                    "executor_id",
+                                                    "gas_burnt",
+                                                    "logs",
+                                                    "metadata",
+                                                    "receipt_ids",
+                                                    "status",
+                                                    "tokens_burnt"
+                                                  ],
+                                                  "additionalProperties": false,
+                                                  "properties": [
+                                                    {
+                                                      "name": "executor_id",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "gas_burnt",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "integer",
+                                                        "format": "uint64"
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "logs",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "metadata",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "object",
+                                                        "additionalProperties": true
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "receipt_ids",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "status",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "oneOf": [
+                                                          {
+                                                            "type": "object",
+                                                            "required": [
+                                                              "SuccessReceiptId"
+                                                            ],
+                                                            "additionalProperties": false,
+                                                            "properties": [
+                                                              {
+                                                                "name": "SuccessReceiptId",
+                                                                "required": true,
+                                                                "schema": {
+                                                                  "type": "string"
+                                                                }
+                                                              }
+                                                            ],
+                                                            "refName": "ExecutionOutcomeStatusSuccessReceiptId"
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "required": [
+                                                              "SuccessValue"
+                                                            ],
+                                                            "additionalProperties": false,
+                                                            "properties": [
+                                                              {
+                                                                "name": "SuccessValue",
+                                                                "required": true,
+                                                                "schema": {
+                                                                  "type": "string"
+                                                                }
+                                                              }
+                                                            ],
+                                                            "refName": "ExecutionOutcomeStatusSuccessValue"
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "required": [
+                                                              "Failure"
+                                                            ],
+                                                            "additionalProperties": false,
+                                                            "properties": [
+                                                              {
+                                                                "name": "Failure",
+                                                                "required": true,
+                                                                "schema": {
+                                                                  "type": "object",
+                                                                  "additionalProperties": true
+                                                                }
+                                                              }
+                                                            ],
+                                                            "refName": "ExecutionOutcomeStatusFailure"
+                                                          }
+                                                        ],
+                                                        "refName": "ExecutionOutcomeStatus"
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "tokens_burnt",
+                                                      "required": true,
+                                                      "schema": {
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  ],
+                                                  "refName": "ExecutionOutcomeSummary"
+                                                }
+                                              },
+                                              {
+                                                "name": "proof",
+                                                "required": true,
+                                                "schema": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "object",
+                                                    "additionalProperties": true,
+                                                    "refName": "ExecutionProofItem"
+                                                  }
+                                                }
+                                              }
+                                            ],
+                                            "refName": "ExecutionOutcomeDocument"
+                                          }
+                                        },
+                                        {
+                                          "name": "receipt",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "object",
+                                            "description": "Receipt payload when neardata includes it for this entry.",
+                                            "oneOf": [
+                                              {
+                                                "type": "object",
+                                                "description": "Receipt object as served by neardata inside a chunk payload.",
+                                                "required": [
+                                                  "predecessor_id",
+                                                  "priority",
+                                                  "receipt",
+                                                  "receipt_id",
+                                                  "receiver_id"
+                                                ],
+                                                "additionalProperties": false,
+                                                "properties": [
+                                                  {
+                                                    "name": "predecessor_id",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "priority",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "integer",
+                                                      "format": "uint64"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "receipt",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "oneOf": [
+                                                        {
+                                                          "type": "object",
+                                                          "required": [
+                                                            "Action"
+                                                          ],
+                                                          "additionalProperties": false,
+                                                          "properties": [
+                                                            {
+                                                              "name": "Action",
+                                                              "required": true,
+                                                              "schema": {
+                                                                "type": "object",
+                                                                "required": [
+                                                                  "actions",
+                                                                  "gas_price",
+                                                                  "input_data_ids",
+                                                                  "is_promise_yield",
+                                                                  "output_data_receivers",
+                                                                  "signer_id",
+                                                                  "signer_public_key"
+                                                                ],
+                                                                "additionalProperties": false,
+                                                                "properties": [
+                                                                  {
+                                                                    "name": "actions",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "array",
+                                                                      "items": {
+                                                                        "type": "object",
+                                                                        "additionalProperties": true,
+                                                                        "refName": "ActionDocument"
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "gas_price",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "input_data_ids",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "array",
+                                                                      "items": {
+                                                                        "type": "string"
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "is_promise_yield",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "boolean"
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "output_data_receivers",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "array",
+                                                                      "items": {
+                                                                        "type": "object",
+                                                                        "required": [
+                                                                          "data_id",
+                                                                          "receiver_id"
+                                                                        ],
+                                                                        "additionalProperties": false,
+                                                                        "properties": [
+                                                                          {
+                                                                            "name": "data_id",
+                                                                            "required": true,
+                                                                            "schema": {
+                                                                              "type": "string"
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "name": "receiver_id",
+                                                                            "required": true,
+                                                                            "schema": {
+                                                                              "type": "string"
+                                                                            }
+                                                                          }
+                                                                        ],
+                                                                        "refName": "OutputDataReceiverDocument"
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "signer_id",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "signer_public_key",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  }
+                                                                ],
+                                                                "refName": "ActionReceiptDocument"
+                                                              }
+                                                            }
+                                                          ],
+                                                          "refName": "ActionReceiptBody"
+                                                        },
+                                                        {
+                                                          "type": "object",
+                                                          "required": [
+                                                            "Data"
+                                                          ],
+                                                          "additionalProperties": false,
+                                                          "properties": [
+                                                            {
+                                                              "name": "Data",
+                                                              "required": true,
+                                                              "schema": {
+                                                                "type": "object",
+                                                                "required": [
+                                                                  "data",
+                                                                  "data_id",
+                                                                  "is_promise_resume"
+                                                                ],
+                                                                "additionalProperties": false,
+                                                                "properties": [
+                                                                  {
+                                                                    "name": "data",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "data_id",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "name": "is_promise_resume",
+                                                                    "required": true,
+                                                                    "schema": {
+                                                                      "type": "boolean"
+                                                                    }
+                                                                  }
+                                                                ],
+                                                                "refName": "DataReceiptDocument"
+                                                              }
+                                                            }
+                                                          ],
+                                                          "refName": "DataReceiptBody"
+                                                        }
+                                                      ],
+                                                      "refName": "ReceiptBody"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "receipt_id",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  {
+                                                    "name": "receiver_id",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                ],
+                                                "refName": "ReceiptDocument"
+                                              },
+                                              {
+                                                "type": "object",
+                                                "additionalProperties": false,
+                                                "refName": "OmittedReceiptDocument"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "name": "tx_hash",
+                                          "required": false,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      ],
+                                      "refName": "ExecutionWithReceipt"
+                                    }
+                                  },
+                                  {
+                                    "name": "transaction",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "object",
+                                      "required": [
+                                        "actions",
+                                        "hash",
+                                        "nonce",
+                                        "priority_fee",
+                                        "public_key",
+                                        "receiver_id",
+                                        "signature",
+                                        "signer_id"
+                                      ],
+                                      "additionalProperties": false,
+                                      "properties": [
+                                        {
+                                          "name": "actions",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "additionalProperties": true,
+                                              "refName": "ActionDocument"
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "name": "hash",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        {
+                                          "name": "nonce",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "integer",
+                                            "format": "uint64"
+                                          }
+                                        },
+                                        {
+                                          "name": "priority_fee",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "integer",
+                                            "format": "uint64"
+                                          }
+                                        },
+                                        {
+                                          "name": "public_key",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        {
+                                          "name": "receiver_id",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        {
+                                          "name": "signature",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        {
+                                          "name": "signer_id",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      ],
+                                      "refName": "SignedTransactionDocument"
+                                    }
+                                  }
+                                ],
+                                "refName": "ChunkTransactionWrapper"
+                              }
+                            }
+                          }
+                        ],
+                        "refName": "ChunkDocument"
+                      }
+                    },
+                    {
+                      "name": "receipt_execution_outcomes",
+                      "required": true,
+                      "schema": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "description": "Execution result paired with an optional receipt object.",
+                          "required": [
+                            "execution_outcome",
+                            "receipt"
+                          ],
+                          "additionalProperties": false,
+                          "properties": [
+                            {
+                              "name": "execution_outcome",
+                              "required": true,
+                              "schema": {
+                                "type": "object",
+                                "required": [
+                                  "block_hash",
+                                  "id",
+                                  "outcome",
+                                  "proof"
+                                ],
+                                "additionalProperties": false,
+                                "properties": [
+                                  {
+                                    "name": "block_hash",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  {
+                                    "name": "id",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  {
+                                    "name": "outcome",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "object",
+                                      "required": [
+                                        "executor_id",
+                                        "gas_burnt",
+                                        "logs",
+                                        "metadata",
+                                        "receipt_ids",
+                                        "status",
+                                        "tokens_burnt"
+                                      ],
+                                      "additionalProperties": false,
+                                      "properties": [
+                                        {
+                                          "name": "executor_id",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        {
+                                          "name": "gas_burnt",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "integer",
+                                            "format": "uint64"
+                                          }
+                                        },
+                                        {
+                                          "name": "logs",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "name": "metadata",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "object",
+                                            "additionalProperties": true
+                                          }
+                                        },
+                                        {
+                                          "name": "receipt_ids",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "name": "status",
+                                          "required": true,
+                                          "schema": {
+                                            "oneOf": [
+                                              {
+                                                "type": "object",
+                                                "required": [
+                                                  "SuccessReceiptId"
+                                                ],
+                                                "additionalProperties": false,
+                                                "properties": [
+                                                  {
+                                                    "name": "SuccessReceiptId",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                ],
+                                                "refName": "ExecutionOutcomeStatusSuccessReceiptId"
+                                              },
+                                              {
+                                                "type": "object",
+                                                "required": [
+                                                  "SuccessValue"
+                                                ],
+                                                "additionalProperties": false,
+                                                "properties": [
+                                                  {
+                                                    "name": "SuccessValue",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                ],
+                                                "refName": "ExecutionOutcomeStatusSuccessValue"
+                                              },
+                                              {
+                                                "type": "object",
+                                                "required": [
+                                                  "Failure"
+                                                ],
+                                                "additionalProperties": false,
+                                                "properties": [
+                                                  {
+                                                    "name": "Failure",
+                                                    "required": true,
+                                                    "schema": {
+                                                      "type": "object",
+                                                      "additionalProperties": true
+                                                    }
+                                                  }
+                                                ],
+                                                "refName": "ExecutionOutcomeStatusFailure"
+                                              }
+                                            ],
+                                            "refName": "ExecutionOutcomeStatus"
+                                          }
+                                        },
+                                        {
+                                          "name": "tokens_burnt",
+                                          "required": true,
+                                          "schema": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      ],
+                                      "refName": "ExecutionOutcomeSummary"
+                                    }
+                                  },
+                                  {
+                                    "name": "proof",
+                                    "required": true,
+                                    "schema": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "additionalProperties": true,
+                                        "refName": "ExecutionProofItem"
+                                      }
+                                    }
+                                  }
+                                ],
+                                "refName": "ExecutionOutcomeDocument"
+                              }
+                            },
+                            {
+                              "name": "receipt",
+                              "required": true,
+                              "schema": {
+                                "type": "object",
+                                "description": "Receipt payload when neardata includes it for this entry.",
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "description": "Receipt object as served by neardata inside a chunk payload.",
+                                    "required": [
+                                      "predecessor_id",
+                                      "priority",
+                                      "receipt",
+                                      "receipt_id",
+                                      "receiver_id"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "predecessor_id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "priority",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "integer",
+                                          "format": "uint64"
+                                        }
+                                      },
+                                      {
+                                        "name": "receipt",
+                                        "required": true,
+                                        "schema": {
+                                          "oneOf": [
+                                            {
+                                              "type": "object",
+                                              "required": [
+                                                "Action"
+                                              ],
+                                              "additionalProperties": false,
+                                              "properties": [
+                                                {
+                                                  "name": "Action",
+                                                  "required": true,
+                                                  "schema": {
+                                                    "type": "object",
+                                                    "required": [
+                                                      "actions",
+                                                      "gas_price",
+                                                      "input_data_ids",
+                                                      "is_promise_yield",
+                                                      "output_data_receivers",
+                                                      "signer_id",
+                                                      "signer_public_key"
+                                                    ],
+                                                    "additionalProperties": false,
+                                                    "properties": [
+                                                      {
+                                                        "name": "actions",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "additionalProperties": true,
+                                                            "refName": "ActionDocument"
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "gas_price",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "input_data_ids",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "string"
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "is_promise_yield",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "output_data_receivers",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "required": [
+                                                              "data_id",
+                                                              "receiver_id"
+                                                            ],
+                                                            "additionalProperties": false,
+                                                            "properties": [
+                                                              {
+                                                                "name": "data_id",
+                                                                "required": true,
+                                                                "schema": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              {
+                                                                "name": "receiver_id",
+                                                                "required": true,
+                                                                "schema": {
+                                                                  "type": "string"
+                                                                }
+                                                              }
+                                                            ],
+                                                            "refName": "OutputDataReceiverDocument"
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "signer_id",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "signer_public_key",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "string"
+                                                        }
+                                                      }
+                                                    ],
+                                                    "refName": "ActionReceiptDocument"
+                                                  }
+                                                }
+                                              ],
+                                              "refName": "ActionReceiptBody"
+                                            },
+                                            {
+                                              "type": "object",
+                                              "required": [
+                                                "Data"
+                                              ],
+                                              "additionalProperties": false,
+                                              "properties": [
+                                                {
+                                                  "name": "Data",
+                                                  "required": true,
+                                                  "schema": {
+                                                    "type": "object",
+                                                    "required": [
+                                                      "data",
+                                                      "data_id",
+                                                      "is_promise_resume"
+                                                    ],
+                                                    "additionalProperties": false,
+                                                    "properties": [
+                                                      {
+                                                        "name": "data",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "data_id",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      {
+                                                        "name": "is_promise_resume",
+                                                        "required": true,
+                                                        "schema": {
+                                                          "type": "boolean"
+                                                        }
+                                                      }
+                                                    ],
+                                                    "refName": "DataReceiptDocument"
+                                                  }
+                                                }
+                                              ],
+                                              "refName": "DataReceiptBody"
+                                            }
+                                          ],
+                                          "refName": "ReceiptBody"
+                                        }
+                                      },
+                                      {
+                                        "name": "receipt_id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "receiver_id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "ReceiptDocument"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "refName": "OmittedReceiptDocument"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "name": "tx_hash",
+                              "required": false,
+                              "schema": {
+                                "type": "string"
+                              }
+                            }
+                          ],
+                          "refName": "ExecutionWithReceipt"
+                        }
+                      }
+                    },
+                    {
+                      "name": "shard_id",
+                      "required": true,
+                      "schema": {
+                        "type": "integer",
+                        "format": "uint64"
+                      }
+                    },
+                    {
+                      "name": "state_changes",
+                      "required": true,
+                      "schema": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "description": "State change entry returned by neardata for a shard.",
+                          "required": [
+                            "cause",
+                            "change",
+                            "type"
+                          ],
+                          "additionalProperties": false,
+                          "properties": [
+                            {
+                              "name": "cause",
+                              "required": true,
+                              "schema": {
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "required": [
+                                      "tx_hash",
+                                      "type"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "tx_hash",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "type",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "StateChangeCauseTransactionProcessing"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "required": [
+                                      "receipt_hash",
+                                      "type"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "receipt_hash",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "type",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "StateChangeCauseReceiptProcessing"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "required": [
+                                      "receipt_hash",
+                                      "type"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "receipt_hash",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "type",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "StateChangeCauseActionReceiptGasReward"
+                                  }
+                                ],
+                                "refName": "StateChangeCause"
+                              }
+                            },
+                            {
+                              "name": "change",
+                              "required": true,
+                              "schema": {
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "required": [
+                                      "account_id",
+                                      "amount",
+                                      "code_hash",
+                                      "locked",
+                                      "storage_paid_at",
+                                      "storage_usage"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "account_id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "amount",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "code_hash",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "locked",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "storage_paid_at",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "integer",
+                                          "format": "uint64"
+                                        }
+                                      },
+                                      {
+                                        "name": "storage_usage",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "integer",
+                                          "format": "uint64"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "StateChangeValueAccountUpdate"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "required": [
+                                      "access_key",
+                                      "account_id",
+                                      "public_key"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "access_key",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "object",
+                                          "additionalProperties": true
+                                        }
+                                      },
+                                      {
+                                        "name": "account_id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "public_key",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "StateChangeValueAccessKeyUpdate"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "required": [
+                                      "account_id",
+                                      "key_base64",
+                                      "value_base64"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "account_id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "key_base64",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "value_base64",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "StateChangeValueDataUpdate"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "required": [
+                                      "account_id",
+                                      "key_base64"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": [
+                                      {
+                                        "name": "account_id",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      {
+                                        "name": "key_base64",
+                                        "required": true,
+                                        "schema": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ],
+                                    "refName": "StateChangeValueDataDeletion"
+                                  }
+                                ],
+                                "refName": "StateChangeValue"
+                              }
+                            },
+                            {
+                              "name": "type",
+                              "required": true,
+                              "schema": {
+                                "type": "string"
+                              }
+                            }
+                          ],
+                          "refName": "StateChangeItem"
+                        }
+                      }
+                    }
+                  ],
+                  "refName": "ShardDocument"
+                }
+              }
+            }
+          ],
+          "refName": "BlockDocument"
         },
         "status": "200"
       },


### PR DESCRIPTION
Reconciles mike-docs `main` with the **builder-docs baseline** for the REST surface, closing a pre-existing cross-repo drift.

## The drift
builder-docs `main` (commit `db38b01`, "sync richer API schemas") vendored richer **neardata** schemas — `BlockDocument`, `ActionReceiptDocument`, `ShardDocument`, etc. — from `../fn/neardata-server`, but that mike-docs working state was **never committed back to mike-docs main**. So mike-docs main sat ~11.5k lines behind, and a naïve `generate-page-models` vendor from mike-docs would have *deleted* that live content from builder-docs.

## This PR
- `npm run sync:apis` pulls the current neardata leaf specs into `apis/neardata/**`
- regenerates `shared/generatedFastnearPageModels.json` (8 neardata page models)
- mike-docs page models are now **line-for-line identical to builder-docs main** on the REST surface (36,634 lines)

No builder-docs change is needed — it already has this content; mike-docs is simply catching up so it's a consistent source of truth again.

Validated: `audit:page-model-routes`, `audit:structured-graph`, redocly lint — all green.

## Known follow-up (not in this PR)
7 **RPC** operations still differ between mike-docs main and builder-docs main:
- **4 field-level** (`call-function` args_base64, `tx-status` / `EXPERIMENTAL-tx-status` signed_tx_base64, `view-state` prefix_base64) — builder-docs has richer curated field text; recover into mike-docs via the new `op.fieldDescriptions` layer once fastnear/docs-pipeline#5 lands.
- **3 tx op-descriptions** (`broadcast-tx-async` / `broadcast-tx-commit` / `send-tx`) — mike-docs has the newer "Base64-encoded" sweep wording, builder-docs has an extra "illustrative only" caveat; needs a one-line editorial merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
