### PR TITLE
docs(rpc): recover + technicalize 7 RPC descriptions (nearcore #16069)

### DIFF
--- a/rpcs/contract/call.yaml
+++ b/rpcs/contract/call.yaml
@@ -39,7 +39,7 @@ paths:
                       description: NEAR account ID
                     args_base64:
                       type: string
-                      description: Base64-encoded method arguments
+                      description: "Base64-encoded argument byte array passed to the method. JSON contracts expect the UTF-8 bytes of the JSON payload (`e30=` decodes to `{}`)."
                     method_name:
                       type: string
                       description: Name of the contract view method to invoke.

--- a/rpcs/transaction/EXPERIMENTAL_tx_status.yaml
+++ b/rpcs/transaction/EXPERIMENTAL_tx_status.yaml
@@ -47,7 +47,7 @@ paths:
                       default: EXECUTED_OPTIMISTIC
                     signed_tx_base64:
                       type: string
-                      description: Base64-encoded signed transaction
+                      description: "Base64-encoded Borsh serialization of a `SignedTransaction`; must be freshly signed (nonce above the access key's current value)."
                     sender_account_id:
                       type: string
                       description: NEAR account ID

--- a/rpcs/transaction/broadcast_tx_async.yaml
+++ b/rpcs/transaction/broadcast_tx_async.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: "NEAR Protocol RPC: Send transaction asynchronously"
-  description: Submit a Base64-encoded signed transaction and immediately get its hash — no wait for execution.
+  description: "Broadcast a base64-encoded `SignedTransaction`; returns the transaction hash without awaiting inclusion or execution. Example payloads are placeholders and cannot be replayed."
   version: 1.0.0
 servers:
   - url: "https://rpc.mainnet.fastnear.com"
@@ -13,7 +13,7 @@ paths:
     post:
       operationId: broadcast_tx_async
       summary: Send transaction asynchronously
-      description: Submit a Base64-encoded signed transaction and immediately get its hash — no wait for execution.
+      description: "Broadcast a base64-encoded `SignedTransaction`; returns the transaction hash without awaiting inclusion or execution. Example payloads are placeholders and cannot be replayed."
       requestBody:
         required: true
         content:

--- a/rpcs/transaction/broadcast_tx_commit.yaml
+++ b/rpcs/transaction/broadcast_tx_commit.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: "NEAR Protocol RPC: Send transaction and wait"
-  description: "Submit a Base64-encoded signed transaction and wait for its commit — the legacy synchronous send, superseded by `send_tx`."
+  description: "Broadcast a base64-encoded `SignedTransaction`; blocks until execution completes or a 10-second timeout elapses. Deprecated — use `send_tx`. Example payloads are placeholders and cannot be replayed."
   version: 1.0.0
 servers:
   - url: "https://rpc.mainnet.fastnear.com"
@@ -13,7 +13,7 @@ paths:
     post:
       operationId: broadcast_tx_commit
       summary: Send transaction and wait
-      description: "Submit a Base64-encoded signed transaction and wait for its commit — the legacy synchronous send, superseded by `send_tx`."
+      description: "Broadcast a base64-encoded `SignedTransaction`; blocks until execution completes or a 10-second timeout elapses. Deprecated — use `send_tx`. Example payloads are placeholders and cannot be replayed."
       requestBody:
         required: true
         content:

--- a/rpcs/transaction/send_tx.yaml
+++ b/rpcs/transaction/send_tx.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: "NEAR Protocol RPC: Send transaction"
-  description: Submit a Base64-encoded signed transaction and wait for its final execution outcome — the current synchronous send.
+  description: "Broadcast a base64-encoded `SignedTransaction`; blocks until the execution outcome specified by `wait_until`. Example payloads are placeholders and cannot be replayed."
   version: 1.0.0
 servers:
   - url: "https://rpc.mainnet.fastnear.com"
@@ -13,7 +13,7 @@ paths:
     post:
       operationId: send_tx
       summary: Send transaction
-      description: Submit a Base64-encoded signed transaction and wait for its final execution outcome — the current synchronous send.
+      description: "Broadcast a base64-encoded `SignedTransaction`; blocks until the execution outcome specified by `wait_until`. Example payloads are placeholders and cannot be replayed."
       requestBody:
         required: true
         content:

--- a/rpcs/transaction/tx_status.yaml
+++ b/rpcs/transaction/tx_status.yaml
@@ -47,7 +47,7 @@ paths:
                       default: EXECUTED_OPTIMISTIC
                     signed_tx_base64:
                       type: string
-                      description: Base64-encoded signed transaction
+                      description: "Base64-encoded Borsh serialization of a `SignedTransaction`; must be freshly signed (nonce above the access key's current value)."
                     sender_account_id:
                       type: string
                       description: NEAR account ID

--- a/scripts/nearcore-operation-map.js
+++ b/scripts/nearcore-operation-map.js
@@ -257,6 +257,11 @@ const OPERATIONS = [
     operationId: 'call_function',
     summary: 'Call contract function',
     description: "Invoke a contract view method without gas or state changes — reads computed values from contract logic.",
+    fieldDescriptions: {
+      request: {
+        args_base64: 'Base64-encoded argument byte array passed to the method. JSON contracts expect the UTF-8 bytes of the JSON payload (`e30=` decodes to `{}`).',
+      },
+    },
   },
   {
     type: 'query',
@@ -476,7 +481,7 @@ const OPERATIONS = [
     category: 'transaction',
     operationId: 'broadcast_tx_async',
     summary: 'Send transaction asynchronously',
-    description: "Submit a Base64-encoded signed transaction and immediately get its hash — no wait for execution.",
+    description: "Broadcast a base64-encoded `SignedTransaction`; returns the transaction hash without awaiting inclusion or execution. Example payloads are placeholders and cannot be replayed.",
   },
   {
     type: 'simple',
@@ -485,7 +490,7 @@ const OPERATIONS = [
     category: 'transaction',
     operationId: 'broadcast_tx_commit',
     summary: 'Send transaction and wait',
-    description: "Submit a Base64-encoded signed transaction and wait for its commit — the legacy synchronous send, superseded by `send_tx`.",
+    description: "Broadcast a base64-encoded `SignedTransaction`; blocks until execution completes or a 10-second timeout elapses. Deprecated — use `send_tx`. Example payloads are placeholders and cannot be replayed.",
   },
   {
     type: 'simple',
@@ -495,6 +500,11 @@ const OPERATIONS = [
     operationId: 'tx_status',
     summary: 'Get transaction status',
     description: "Check a transaction's final outcome by Base58 hash — succeeded, failed, or still unresolved.",
+    fieldDescriptions: {
+      request: {
+        signed_tx_base64: "Base64-encoded Borsh serialization of a `SignedTransaction`; must be freshly signed (nonce above the access key's current value).",
+      },
+    },
     exampleParamsByNetwork: {
       mainnet: {
         tx_hash: 'ESShk21GZb6cgFRoJyEJqdJXuoP72fuCmCn6pNMhXFC7',
@@ -509,7 +519,7 @@ const OPERATIONS = [
     category: 'transaction',
     operationId: 'send_tx',
     summary: 'Send transaction',
-    description: "Submit a Base64-encoded signed transaction and wait for its final execution outcome — the current synchronous send.",
+    description: "Broadcast a base64-encoded `SignedTransaction`; blocks until the execution outcome specified by `wait_until`. Example payloads are placeholders and cannot be replayed.",
   },
 
   // === Validator operations ===
@@ -541,6 +551,11 @@ const OPERATIONS = [
     operationId: 'EXPERIMENTAL_tx_status',
     summary: 'Get detailed transaction status',
     description: "Fetch a transaction's full receipt tree and per-receipt outcomes by Base58 hash — richer than `tx_status`.",
+    fieldDescriptions: {
+      request: {
+        signed_tx_base64: "Base64-encoded Borsh serialization of a `SignedTransaction`; must be freshly signed (nonce above the access key's current value).",
+      },
+    },
     exampleParamsByNetwork: {
       mainnet: {
         tx_hash: 'ESShk21GZb6cgFRoJyEJqdJXuoP72fuCmCn6pNMhXFC7',

--- a/shared/generatedFastnearPageModels.json
+++ b/shared/generatedFastnearPageModels.json
@@ -1814,14 +1814,14 @@
           }
         },
         {
-          "description": "Base64-encoded method arguments",
+          "description": "Base64-encoded argument byte array passed to the method. JSON contracts expect the UTF-8 bytes of the JSON payload (`e30=` decodes to `{}`).",
           "label": "Args Base64",
           "location": "body",
           "name": "args_base64",
           "required": true,
           "schema": {
             "type": "string",
-            "description": "Base64-encoded method arguments"
+            "description": "Base64-encoded argument byte array passed to the method. JSON contracts expect the UTF-8 bytes of the JSON payload (`e30=` decodes to `{}`)."
           }
         },
         {
@@ -1930,7 +1930,7 @@
                   "required": true,
                   "schema": {
                     "type": "string",
-                    "description": "Base64-encoded method arguments"
+                    "description": "Base64-encoded argument byte array passed to the method. JSON contracts expect the UTF-8 bytes of the JSON payload (`e30=` decodes to `{}`)."
                   }
                 },
                 {
@@ -11917,14 +11917,14 @@
           }
         },
         {
-          "description": "Base64-encoded signed transaction",
+          "description": "Base64-encoded Borsh serialization of a `SignedTransaction`; must be freshly signed (nonce above the access key's current value).",
           "label": "Signed Tx Base64",
           "location": "body",
           "name": "signed_tx_base64",
           "required": false,
           "schema": {
             "type": "string",
-            "description": "Base64-encoded signed transaction"
+            "description": "Base64-encoded Borsh serialization of a `SignedTransaction`; must be freshly signed (nonce above the access key's current value)."
           }
         },
         {
@@ -12045,7 +12045,7 @@
                   "required": false,
                   "schema": {
                     "type": "string",
-                    "description": "Base64-encoded signed transaction"
+                    "description": "Base64-encoded Borsh serialization of a `SignedTransaction`; must be freshly signed (nonce above the access key's current value)."
                   }
                 },
                 {
@@ -12287,7 +12287,7 @@
   {
     "canonicalPath": "/rpcs/transaction/broadcast_tx_async",
     "info": {
-      "description": "Submit a Base64-encoded signed transaction and immediately get its hash — no wait for execution.",
+      "description": "Broadcast a base64-encoded `SignedTransaction`; returns the transaction hash without awaiting inclusion or execution. Example payloads are placeholders and cannot be replayed.",
       "operationId": "broadcast_tx_async",
       "summary": "Send transaction asynchronously",
       "title": "NEAR Protocol RPC: Send transaction asynchronously",
@@ -12579,7 +12579,7 @@
   {
     "canonicalPath": "/rpcs/transaction/broadcast_tx_commit",
     "info": {
-      "description": "Submit a Base64-encoded signed transaction and wait for its commit — the legacy synchronous send, superseded by `send_tx`.",
+      "description": "Broadcast a base64-encoded `SignedTransaction`; blocks until execution completes or a 10-second timeout elapses. Deprecated — use `send_tx`. Example payloads are placeholders and cannot be replayed.",
       "operationId": "broadcast_tx_commit",
       "summary": "Send transaction and wait",
       "title": "NEAR Protocol RPC: Send transaction and wait",
@@ -12937,7 +12937,7 @@
   {
     "canonicalPath": "/rpcs/transaction/send_tx",
     "info": {
-      "description": "Submit a Base64-encoded signed transaction and wait for its final execution outcome — the current synchronous send.",
+      "description": "Broadcast a base64-encoded `SignedTransaction`; blocks until the execution outcome specified by `wait_until`. Example payloads are placeholders and cannot be replayed.",
       "operationId": "send_tx",
       "summary": "Send transaction",
       "title": "NEAR Protocol RPC: Send transaction",
@@ -13330,14 +13330,14 @@
           }
         },
         {
-          "description": "Base64-encoded signed transaction",
+          "description": "Base64-encoded Borsh serialization of a `SignedTransaction`; must be freshly signed (nonce above the access key's current value).",
           "label": "Signed Tx Base64",
           "location": "body",
           "name": "signed_tx_base64",
           "required": false,
           "schema": {
             "type": "string",
-            "description": "Base64-encoded signed transaction"
+            "description": "Base64-encoded Borsh serialization of a `SignedTransaction`; must be freshly signed (nonce above the access key's current value)."
           }
         },
         {
@@ -13456,7 +13456,7 @@
                   "required": false,
                   "schema": {
                     "type": "string",
-                    "description": "Base64-encoded signed transaction"
+                    "description": "Base64-encoded Borsh serialization of a `SignedTransaction`; must be freshly signed (nonce above the access key's current value)."
                   }
                 },
                 {

--- a/shared/generatedFastnearStructuredGraph.json
+++ b/shared/generatedFastnearStructuredGraph.json
@@ -1210,7 +1210,7 @@
       "branch": "HEAD",
       "commitSha": "499283a5e3a6f8ea52bc068c28e3a7bebb1e38c0",
       "dirty": true,
-      "generatedAt": "2026-07-14T21:42:43.712Z",
+      "generatedAt": "2026-07-14T21:45:20.697Z",
       "releaseUrl": "https://github.com/near/nearcore/releases/tag/2.13.0",
       "repoRoot": "../nearcore",
       "repoUrl": "https://github.com/near/nearcore",
@@ -3049,7 +3049,7 @@
     {
       "authSummary": "API key via query apiKey",
       "canonicalPath": "/rpcs/transaction/broadcast_tx_async",
-      "description": "Submit a Base64-encoded signed transaction and immediately get its hash — no wait for execution.",
+      "description": "Broadcast a base64-encoded `SignedTransaction`; returns the transaction hash without awaiting inclusion or execution. Example payloads are placeholders and cannot be replayed.",
       "docsPath": "/rpc/transaction/broadcast-tx-async",
       "familyId": "rpc-transaction",
       "headline": "NEAR Protocol RPC: Send transaction asynchronously",
@@ -3076,7 +3076,7 @@
     {
       "authSummary": "API key via query apiKey",
       "canonicalPath": "/rpcs/transaction/broadcast_tx_commit",
-      "description": "Submit a Base64-encoded signed transaction and wait for its commit — the legacy synchronous send, superseded by `send_tx`.",
+      "description": "Broadcast a base64-encoded `SignedTransaction`; blocks until execution completes or a 10-second timeout elapses. Deprecated — use `send_tx`. Example payloads are placeholders and cannot be replayed.",
       "docsPath": "/rpc/transaction/broadcast-tx-commit",
       "familyId": "rpc-transaction",
       "headline": "NEAR Protocol RPC: Send transaction and wait",
@@ -3157,7 +3157,7 @@
     {
       "authSummary": "API key via query apiKey",
       "canonicalPath": "/rpcs/transaction/send_tx",
-      "description": "Submit a Base64-encoded signed transaction and wait for its final execution outcome — the current synchronous send.",
+      "description": "Broadcast a base64-encoded `SignedTransaction`; blocks until the execution outcome specified by `wait_until`. Example payloads are placeholders and cannot be replayed.",
       "docsPath": "/rpc/transaction/send-tx",
       "familyId": "rpc-transaction",
       "headline": "NEAR Protocol RPC: Send transaction",


### PR DESCRIPTION
Recovers 7 curated **RPC descriptions** that were live on builder-docs main but missing from mike-docs main (a prior vendor never committed back), rewritten in a **more technical register** per review.

> Stacked on #5 — it uses the `op.fieldDescriptions` layer introduced there. Merge #5 first, then retarget/merge this. Tracks nearcore issue **#16069** (upstream field-doc backfill).

## Field-level (`op.fieldDescriptions`)
- `call_function` `args_base64` — "Base64-encoded argument byte array… JSON contracts expect the UTF-8 bytes of the JSON payload (`e30=` decodes to `{}`)."
- `tx_status` / `EXPERIMENTAL_tx_status` `signed_tx_base64` — "Base64-encoded Borsh serialization of a `SignedTransaction`; must be freshly signed (nonce above the access key's current value)."

## Transaction op-descriptions (`op.description`)
Merged mike-docs's newer "Base64-encoded" wording with builder-docs's placeholder caveat, tightened to protocol terms:
- `broadcast_tx_async` — "…returns the transaction hash without awaiting inclusion or execution."
- `broadcast_tx_commit` — "…blocks until execution completes or a 10-second timeout elapses. Deprecated — use `send_tx`."
- `send_tx` — "…blocks until the execution outcome specified by `wait_until`."

All end with "Example payloads are placeholders and cannot be replayed."

## Register
These moved from a developer-onboarding voice to a protocol-reference voice (encoding + type + constraint over walkthrough), e.g. "Pagination cursor… pass the previous response's `last_key` to fetch the next page" → "Exclusive start cursor: returns only keys greater than this one…" (the view_state pagination fields were tightened the same way in #5).

Validated: `audit:parameter-descriptions` (0), `audit:description-quality` (0/0), `audit:page-model-routes`, redocly lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
